### PR TITLE
Added has_superclass property to ClassOfRepresentationImpl

### DIFF
--- a/src/main/java/uk/gov/gchq/hqdm/model/ClassOfRepresentation.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/ClassOfRepresentation.java
@@ -15,7 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfAssociation} that is {@link RepresentationBySign} or any of its subsets.
+ * A {@link ClassOfAssociation} that is {@link ClassOfRepresentation} or any of
+ * its subsets. This is omitted, in error, in the original HQDM documentation.
  */
-public interface ClassOfRepresentation extends Class {
+public interface ClassOfRepresentation extends ClassOfAssociation {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRepresentationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRepresentationImpl.java
@@ -15,9 +15,11 @@
 package uk.gov.gchq.hqdm.model.impl;
 
 import static uk.gov.gchq.hqdm.iri.HQDM.CLASS_OF_REPRESENTATION;
+import static uk.gov.gchq.hqdm.iri.HQDM.HAS_SUPERCLASS;
 
 import uk.gov.gchq.hqdm.exception.HqdmException;
 import uk.gov.gchq.hqdm.iri.IRI;
+import uk.gov.gchq.hqdm.model.Class;
 import uk.gov.gchq.hqdm.model.ClassOfRepresentation;
 import uk.gov.gchq.hqdm.pojo.HqdmObject;
 
@@ -50,10 +52,24 @@ public class ClassOfRepresentationImpl extends HqdmObject implements ClassOfRepr
 
         /**
          *
+         * @param clazz
+         * @return
+         */
+        public final Builder has_Superclass(final Class clazz) {
+            classOfRepresentationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
+            return this;
+        }
+
+        /**
+         *
          * @return
          * @throws HqdmException
          */
         public ClassOfRepresentation build() throws HqdmException {
+            if (classOfRepresentationImpl.hasValue(HAS_SUPERCLASS)
+                    && classOfRepresentationImpl.value(HAS_SUPERCLASS).isEmpty()) {
+                throw new HqdmException("Property Not Set: has_superclass");
+            }
             return classOfRepresentationImpl;
         }
     }


### PR DESCRIPTION
Resolves #9 

Added the `has_superclass` property to `ClassOfRepresentationImpl.Builder`. This relationship does not appear explicitly within the HQDM EXPRESS, but as it is a subclass of `Class`, it should inherit the `has_superclass` relationship described in this builder. 