### PR TITLE
Documented HQDM code with Javadocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ An introduction to [Magma Core](https://github.com/gchq/MagmaCore) and the HQDM 
 - [Java 15](https://openjdk.java.net/projects/jdk/15/) - Core language
 - [Maven](https://maven.apache.org/) - Dependency management
 
+### Inclusion in other projects
+
+The HQDM Java object library can be incorporated into other maven projects using the dependency:
+
+```xml
+<dependency>
+  <groupId>uk.gov.gchq.hqdm</groupId>
+  <artifactId>hqdm</artifactId>
+  <version>1.0</version>
+</dependency>
+```
+
+_HQDM is not currently hosted on Maven Central, so a local install of this repository will be required._
+
 ## Contributing
 
 We welcome contributions to the project. Detailed information on our ways of working can be found [here](CONTRIBUTING.md).

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -7,7 +7,4 @@
   <suppress checks="ConstantName" files="HQDM.java" />
   <suppress checks="AbbreviationAsWordInName" files="IRI.java|HQDM.java|RDFS.java" />
   <suppress checks="TypeName" files="Function_.java" />
-
-  <!-- Javadoc Suppressions -->
-  <suppress checks="SummaryJavadoc|JavadocParagraph|SingleLineJavadoc|AtclauseOrder|NonEmptyAtclauseDescription" files=".java" />
 </suppressions>

--- a/src/main/java/uk/gov/gchq/hqdm/exception/HqdmException.java
+++ b/src/main/java/uk/gov/gchq/hqdm/exception/HqdmException.java
@@ -20,32 +20,44 @@ package uk.gov.gchq.hqdm.exception;
 public class HqdmException extends RuntimeException {
 
     /**
-     *
+     * Constructs a new HqdmException with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause(Throwable)}.
      */
     public HqdmException() {
         super();
     }
 
     /**
+     * Constructs a new HqdmException with the specified detail message. The cause is not
+     * initialized, and may subsequently be initialized by a call to {@link #initCause(Throwable)}.
      *
-     * @param message
+     * @param message The detail message. The detail message is saved for later retrieval by the
+     *        {@link #getMessage()} method.
      */
     public HqdmException(final String message) {
         super(message);
     }
 
     /**
+     * Constructs a new HqdmException with the specified cause and a detail message of (cause==null
+     * ? null : cause.toString()) (which typically contains the class and detail message of cause).
      *
-     * @param cause
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *        method). (A {@code null} value is permitted, and indicates that the cause is
+     *        nonexistent or unknown.)
      */
     public HqdmException(final Throwable cause) {
         super(cause);
     }
 
     /**
+     * Constructs a new HqdmException with the specified detail message and cause.
      *
-     * @param message
-     * @param cause
+     * @param message The detail message (which is saved for later retrieval by the
+     *        {@link #getMessage()} method).
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *        method). (A {@code null} value is permitted, and indicates that the cause is
+     *        nonexistent or unknown.)
      */
     public HqdmException(final String message, final Throwable cause) {
         super(message, cause);

--- a/src/main/java/uk/gov/gchq/hqdm/exception/IriException.java
+++ b/src/main/java/uk/gov/gchq/hqdm/exception/IriException.java
@@ -20,32 +20,44 @@ package uk.gov.gchq.hqdm.exception;
 public class IriException extends HqdmException {
 
     /**
-     *
+     * Constructs a new IriException with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause(Throwable)}.
      */
     public IriException() {
         super();
     }
 
     /**
+     * Constructs a new IriException with the specified detail message. The cause is not
+     * initialized, and may subsequently be initialized by a call to {@link #initCause(Throwable)}.
      *
-     * @param message
+     * @param message The detail message. The detail message is saved for later retrieval by the
+     *        {@link #getMessage()} method.
      */
     public IriException(final String message) {
         super(message);
     }
 
     /**
+     * Constructs a new IriException with the specified cause and a detail message of (cause==null ?
+     * null : cause.toString()) (which typically contains the class and detail message of cause).
      *
-     * @param cause
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *        method). (A {@code null} value is permitted, and indicates that the cause is
+     *        nonexistent or unknown.)
      */
     public IriException(final Throwable cause) {
         super(cause);
     }
 
     /**
+     * Constructs a new IriException with the specified detail message and cause.
      *
-     * @param message
-     * @param cause
+     * @param message The detail message (which is saved for later retrieval by the
+     *        {@link #getMessage()} method).
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *        method). (A {@code null} value is permitted, and indicates that the cause is
+     *        nonexistent or unknown.)
      */
     public IriException(final String message, final Throwable cause) {
         super(message, cause);

--- a/src/main/java/uk/gov/gchq/hqdm/exception/package-info.java
+++ b/src/main/java/uk/gov/gchq/hqdm/exception/package-info.java
@@ -1,4 +1,18 @@
-/**
+/*
+ * Copyright 2021 Crown Copyright
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Exceptions arising from HQDM code.
  */
 package uk.gov.gchq.hqdm.exception;

--- a/src/main/java/uk/gov/gchq/hqdm/iri/HQDM.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/HQDM.java
@@ -15,1056 +15,2313 @@
 package uk.gov.gchq.hqdm.iri;
 
 /**
-*
-*/
+ * IRI definitions for HQDM entities and associations.
+ */
 public final class HQDM {
+
     private HQDM() {}
 
-    /** */
+    /** HQDM namespace. */
     public static final IriBase HQDM = new IriBase("hqdm", "http://www.semanticweb.org/hqdm#");
 
-    /** */
+    /** A unique identifier for a particular HQDM entity. */
     public static final HqdmIri ENTITY_ID = new HqdmIri(HQDM, "data_uniqueID");
 
-    /** */
+    /** A human-interpretable name for a particular HQDM entity. */
     public static final HqdmIri ENTITY_NAME = new HqdmIri(HQDM, "data_EntityName");
 
-    /** */
+    /** Class name of the HQDM Object to which a particular entity belongs. */
     public static final HqdmIri ENTITY_CLASS_NAME = new HqdmIri(HQDM, "class_name");
 
-    /** */
-    public static final HqdmIri SUPERCLASS = new HqdmIri(HQDM, "superclass");
+    // =======================================================================
+    // Entities
+    // =======================================================================
 
-    /** */
-    public static final HqdmIri SUBCLASS = new HqdmIri(HQDM, "subclass");
-
-    /** */
-    public static final HqdmIri SPECIALIZATION = new HqdmIri(HQDM, "specialization");
-
-    /** */
-    public static final HqdmIri CLASSIFICATION = new HqdmIri(HQDM, "classification");
-
-    /** */
-    public static final HqdmIri CLASSIFIER = new HqdmIri(HQDM, "classifier");
-
-    /** */
-    public static final HqdmIri MEMBER = new HqdmIri(HQDM, "member");
-
-    /** */
-    public static final HqdmIri AGGREGATION = new HqdmIri(HQDM, "aggregation");
-
-    /** */
-    public static final HqdmIri COMPOSITION = new HqdmIri(HQDM, "composition");
-
-    /** */
-    public static final HqdmIri ORDINARY_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "ordinary_biological_object");
-
-    /** */
-    public static final HqdmIri PARTICIPANT_IN_ACTIVITY_OR_ASSOCIATION =
-            new HqdmIri(HQDM, "participant_in_activity_or_association");
-
-    /** */
-    public static final HqdmIri PART = new HqdmIri(HQDM, "part");
-
-    /** */
-    public static final HqdmIri WHOLE = new HqdmIri(HQDM, "whole");
-
-    /** */
-    public static final HqdmIri TEMPORAL_COMPOSITION = new HqdmIri(HQDM, "temporal_composition");
-
-    /** */
-    public static final HqdmIri NATURAL_ROLE = new HqdmIri(HQDM, "natural_role");
-
-    /** */
-    public static final HqdmIri TEMPORAL_PART_OF_ = new HqdmIri(HQDM, "temporal_part_of_");
-
-    /** */
-    public static final HqdmIri PART__OF_BY_CLASS = new HqdmIri(HQDM, "part__of_by_class");
-
-    /** */
-    public static final HqdmIri CONSISTS__OF_BY_CLASS = new HqdmIri(HQDM, "consists__of_by_class");
-
-    /** */
-    public static final HqdmIri VALUE_ = new HqdmIri(HQDM, "value_");
-
-    /** */
-    public static final HqdmIri TEMPORAL__PART_OF = new HqdmIri(HQDM, "temporal__part_of");
-
-    /** */
-    public static final HqdmIri PART__OF = new HqdmIri(HQDM, "part__of");
-
-    /** */
-    public static final HqdmIri CONSISTS__OF = new HqdmIri(HQDM, "consists__of");
-
-    /** */
-    public static final HqdmIri MEMBER__OF = new HqdmIri(HQDM, "member__of");
-
-    /** */
+    /** A {@link uk.gov.gchq.hqdm.model.Thing} that does not exist in space or time. */
     public static final HqdmIri ABSTRACT_OBJECT = new HqdmIri(HQDM, "abstract_object");
 
-    /** */
-    public static final HqdmIri OWNER = new HqdmIri(HQDM, "owner");
-
-    /** */
-    public static final HqdmIri ENUMERATED_CLASS = new HqdmIri(HQDM, "enumerated_class");
-
-    /** */
-    public static final HqdmIri EMPLOYER = new HqdmIri(HQDM, "employer");
-
-    /** */
-    public static final HqdmIri EMPLOYEE = new HqdmIri(HQDM, "employee");
-
-    /** */
-    public static final HqdmIri ENDING_OF_OWNERSHIP = new HqdmIri(HQDM, "ending_of_ownership");
-
-    /** */
-    public static final HqdmIri BEGINNING_OF_OWNERSHIP =
-            new HqdmIri(HQDM, "beginning_of_ownership");
-
-    /** */
-    public static final HqdmIri UPPER_BOUND = new HqdmIri(HQDM, "upper_bound");
-
-    /** */
-    public static final HqdmIri LOWER_BOUND = new HqdmIri(HQDM, "lower_bound");
-
-    /** */
-    public static final HqdmIri PHYSICAL_QUANTITY_RANGE =
-            new HqdmIri(HQDM, "physical_quantity_range");
-
-    /** */
-    public static final HqdmIri RANGES_OVER = new HqdmIri(HQDM, "ranges_over");
-
-    /** */
-    public static final HqdmIri INTERSECTION_OF = new HqdmIri(HQDM, "intersection_of");
-
-    /** */
-    public static final HqdmIri DEFINED_BY = new HqdmIri(HQDM, "defined_by");
-
-    /** */
-    public static final HqdmIri PART_OF_PLAN = new HqdmIri(HQDM, "part_of_plan");
-
-    /** */
-    public static final HqdmIri REQUIREMENT = new HqdmIri(HQDM, "requirement");
-
-    /** */
-    public static final HqdmIri DEFINITION = new HqdmIri(HQDM, "definition");
-
-    /** */
-    public static final HqdmIri DESCRIPTION = new HqdmIri(HQDM, "description");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF_IN_MEMBERS =
-            new HqdmIri(HQDM, "consists_of_in_members");
-
-    /** */
-    public static final HqdmIri REPRESENTATION_BY_PATTERN =
-            new HqdmIri(HQDM, "representation_by_pattern");
-
-    /** */
-    public static final HqdmIri CLASS_OF_REPRESENTATION =
-            new HqdmIri(HQDM, "class_of_representation");
-
-    /** */
-    public static final HqdmIri MEMBER_OF_ = new HqdmIri(HQDM, "member_of_");
-
-    /** */
-    public static final HqdmIri ACTIVITY = new HqdmIri(HQDM, "activity");
-
-    /** */
-    public static final HqdmIri STATE_OF_SIGN = new HqdmIri(HQDM, "state_of_sign");
-
-    /** */
-    public static final HqdmIri PRODUCT_OFFERING = new HqdmIri(HQDM, "product_offering");
-
-    /** */
-    public static final HqdmIri PERIOD_OFFERED = new HqdmIri(HQDM, "period_offered");
-
-    /** */
-    public static final HqdmIri OFFEROR = new HqdmIri(HQDM, "offeror");
-
-    /** */
-    public static final HqdmIri CONSIDERATION_BY_CLASS =
-            new HqdmIri(HQDM, "consideration_by_class");
-
-    /** */
-    public static final HqdmIri CLASS_OF_OFFERED = new HqdmIri(HQDM, "class_of_offered");
-
-    /** */
-    public static final HqdmIri OFFERING = new HqdmIri(HQDM, "offering");
-
-    /** */
-    public static final HqdmIri SUCCESSOR = new HqdmIri(HQDM, "successor");
-
-    /** */
-    public static final HqdmIri SOLD_AS = new HqdmIri(HQDM, "sold_as");
-
-    /** */
-    public static final HqdmIri SALES_PRODUCT_VERSION = new HqdmIri(HQDM, "sales_product_version");
-
-    /** */
-    public static final HqdmIri MEETS_SPECIFICATION = new HqdmIri(HQDM, "meets_specification");
-
-    /** */
-    public static final HqdmIri SOLD_UNDER = new HqdmIri(HQDM, "sold_under");
-
-    /** */
-    public static final HqdmIri SALES_PRODUCT = new HqdmIri(HQDM, "sales_product");
-
-    /** */
-    public static final HqdmIri ASSOCIATION = new HqdmIri(HQDM, "association");
-
-    /** */
-    public static final HqdmIri CLASS = new HqdmIri(HQDM, "class");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ACTIVITY = new HqdmIri(HQDM, "class_of_activity");
-
-    /** */
-    public static final HqdmIri CLASS_OF_FUNCTIONAL_SYSTEM =
-            new HqdmIri(HQDM, "class_of_functional_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ORGANIZATION = new HqdmIri(HQDM, "class_of_organization");
-
-    /** */
-    public static final HqdmIri KIND_OF_ORGANIZATION = new HqdmIri(HQDM, "kind_of_organization");
-
-    /** */
-    public static final HqdmIri CLASS_OF_POSSIBLE_WORLD =
-            new HqdmIri(HQDM, "class_of_possible_world");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SYSTEM = new HqdmIri(HQDM, "class_of_system");
-
-    /** */
-    public static final HqdmIri FUNCTIONAL_SYSTEM = new HqdmIri(HQDM, "functional_system");
-
-    /** */
-    public static final HqdmIri IDENTIFICATION = new HqdmIri(HQDM, "identification");
-
-    /** */
-    public static final HqdmIri KIND_OF_ACTIVITY = new HqdmIri(HQDM, "kind_of_activity");
-
-    /** */
-    public static final HqdmIri KIND_OF_ASSOCIATION = new HqdmIri(HQDM, "kind_of_association");
-
-    /** */
-    public static final HqdmIri KIND_OF_INDIVIDUAL = new HqdmIri(HQDM, "kind_of_individual");
-
-    /** */
-    public static final HqdmIri ORGANIZATION = new HqdmIri(HQDM, "organization");
-
-    /** */
-    public static final HqdmIri PATTERN = new HqdmIri(HQDM, "pattern");
-
-    /** */
-    public static final HqdmIri PERSON = new HqdmIri(HQDM, "person");
-
-    /** */
-    public static final HqdmIri POINT_IN_TIME = new HqdmIri(HQDM, "point_in_time");
-
-    /** */
-    public static final HqdmIri POSSIBLE_WORLD = new HqdmIri(HQDM, "possible_world");
-
-    /** */
-    public static final HqdmIri RECOGNIZING_LANGUAGE_COMMUNITY =
-            new HqdmIri(HQDM, "recognizing_language_community");
-
-    /** */
-    public static final HqdmIri REPRESENTATION_BY_SIGN =
-            new HqdmIri(HQDM, "representation_by_sign");
-
-    /** */
-    public static final HqdmIri SIGN = new HqdmIri(HQDM, "sign");
-
-    /** */
-    public static final HqdmIri SPATIO_TEMPORAL_EXTENT =
-            new HqdmIri(HQDM, "spatio_temporal_extent");
-
-    /** */
-    public static final HqdmIri THING = new HqdmIri(HQDM, "thing");
-
-    /** */
-    public static final HqdmIri PART_OF_BY_CLASS = new HqdmIri(HQDM, "part_of_by_class");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF_BY_CLASS = new HqdmIri(HQDM, "consists_of_by_class");
-
-    /** */
-    public static final HqdmIri INTENDED_ROLE_BY_CLASS =
-            new HqdmIri(HQDM, "intended_role_by_class");
-
-    /** */
-    public static final HqdmIri HAS_COMPONENT_BY_CLASS =
-            new HqdmIri(HQDM, "has_component_by_class");
-
-    /** */
-    public static final HqdmIri NATURAL_ROLE_BY_CLASS = new HqdmIri(HQDM, "natural_role_by_class");
-
-    /** */
-    public static final HqdmIri USES = new HqdmIri(HQDM, "uses");
-
-    /** */
-    public static final HqdmIri REPRESENTED = new HqdmIri(HQDM, "represented");
-
-    /** */
-    public static final HqdmIri DOMAIN = new HqdmIri(HQDM, "domain");
-
-    /** */
-    public static final HqdmIri UNIT = new HqdmIri(HQDM, "unit");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF_PARTICIPANT =
-            new HqdmIri(HQDM, "consists_of_participant");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF_PARTICIPANT_ =
-            new HqdmIri(HQDM, "consists_of_participant_");
-
-    /** */
-    public static final HqdmIri DETERMINES = new HqdmIri(HQDM, "determines");
-
-    /** */
-    public static final HqdmIri ROLE = new HqdmIri(HQDM, "role");
-
-    /** */
-    public static final HqdmIri PART_OF_BY_CLASS_ = new HqdmIri(HQDM, "part_of_by_class_");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
-            new HqdmIri(HQDM, "class_of_state_of_socially_constructed_activity");
-
-    /** */
-    public static final HqdmIri CAUSES_BY_CLASS = new HqdmIri(HQDM, "causes_by_class");
-
-    /** */
-    public static final HqdmIri REFERENCES_BY_CLASS = new HqdmIri(HQDM, "references_by_class");
-
-    /** */
-    public static final HqdmIri DETERMINES_BY_CLASS = new HqdmIri(HQDM, "determines_by_class");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
-            new HqdmIri(HQDM, "class_of_socially_constructed_activity");
-
-    /** */
-    public static final HqdmIri STATE_OF_SYSTEM = new HqdmIri(HQDM, "state_of_system");
-
-    /** */
-    public static final HqdmIri SYSTEM = new HqdmIri(HQDM, "system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_BIOLOGICAL_SYSTEM =
-            new HqdmIri(HQDM, "class_of_biological_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PARTY = new HqdmIri(HQDM, "class_of_party");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM =
-            new HqdmIri(HQDM, "class_of_state_of_functional_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM =
-            new HqdmIri(HQDM, "class_of_state_of_biological_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_PARTY =
-            new HqdmIri(HQDM, "class_of_state_of_party");
-
-    /** */
-    public static final HqdmIri STATE_OF_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "state_of_system_component");
-
-    /** */
-    public static final HqdmIri SYSTEM_COMPONENT = new HqdmIri(HQDM, "system_component");
-
-    /** */
-    public static final HqdmIri COMPONENT_OF = new HqdmIri(HQDM, "component_of");
-
-    /** */
-    public static final HqdmIri CLASS_OF_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_functional_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_BIOLOGICAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_biological_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ORGANIZATION_COMPONENT =
-            new HqdmIri(HQDM, "class_of_organization_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_state_of_functional_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_state_of_biological_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ORGANIZATION_COMPONENT =
-            new HqdmIri(HQDM, "class_of_state_of_organization_component");
-
-    /** */
-    public static final HqdmIri INSTALLED_OBJECT = new HqdmIri(HQDM, "installed_object");
-
-    /** */
-    public static final HqdmIri STATE_OF_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_biological_object");
-
-    /** */
-    public static final HqdmIri BIOLOGICAL_OBJECT = new HqdmIri(HQDM, "biological_object");
-
-    /** */
-    public static final HqdmIri STATE_OF_ORDINARY_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_ordinary_biological_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_IN_PLACE_BIOLOGICAL_COMPONENT =
-            new HqdmIri(HQDM, "class_of_in_place_biological_component");
-
-    /** */
-    public static final HqdmIri STATE_OF_BIOLOGICAL_SYSTEM =
-            new HqdmIri(HQDM, "state_of_biological_system");
-
-    /** */
-    public static final HqdmIri BIOLOGICAL_SYSTEM = new HqdmIri(HQDM, "biological_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_PERSON =
-            new HqdmIri(HQDM, "class_of_state_of_person");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PERSON = new HqdmIri(HQDM, "class_of_person");
-
-    /** */
-    public static final HqdmIri STATE_OF_PERSON = new HqdmIri(HQDM, "state_of_person");
-
-    /** */
-    public static final HqdmIri KIND_OF_PERSON = new HqdmIri(HQDM, "kind_of_person");
-
-    /** */
-    public static final HqdmIri BIOLOGICAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "biological_system_component");
-
-    /** */
-    public static final HqdmIri IN_PLACE_BIOLOGICAL_COMPONENT =
-            new HqdmIri(HQDM, "in_place_biological_component");
-
-    /** */
-    public static final HqdmIri STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "state_of_intentionally_constructed_object");
-
-    /** */
-    public static final HqdmIri INTENTIONALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "intentionally_constructed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_socially_constructed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SOCIALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "class_of_socially_constructed_object");
-
-    /** */
-    public static final HqdmIri STATE_OF_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_functional_object");
-
-    /** */
-    public static final HqdmIri FUNCTIONAL_OBJECT = new HqdmIri(HQDM, "functional_object");
-
-    /** */
-    public static final HqdmIri INTENDED_ROLE = new HqdmIri(HQDM, "intended_role");
-
-    /** */
-    public static final HqdmIri STATE_OF_ORDINARY_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_ordinary_functional_object");
-
-    /** */
-    public static final HqdmIri ORDINARY_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "ordinary_functional_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SALES_PRODUCT_INSTANCE =
-            new HqdmIri(HQDM, "class_of_state_of_sales_product_instance");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SALES_PRODUCT_INSTANCE =
-            new HqdmIri(HQDM, "class_of_sales_product_instance");
-
-    /** */
-    public static final HqdmIri STATE_OF_FUNCTIONAL_SYSTEM =
-            new HqdmIri(HQDM, "state_of_functional_system");
-
-    /** */
-    public static final HqdmIri STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "state_of_functional_system_component");
-
-    /** */
-    public static final HqdmIri INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "installed_functional_system_component");
-
-    /** */
-    public static final HqdmIri FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "functional_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_installed_functional_system_component");
-
-    /** */
-    public static final HqdmIri STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "state_of_socially_constructed_object");
-
-    /** */
-    public static final HqdmIri SOCIALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "socially_constructed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ORGANIZATION =
-            new HqdmIri(HQDM, "class_of_state_of_organization");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SIGN =
-            new HqdmIri(HQDM, "class_of_state_of_sign");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SIGN = new HqdmIri(HQDM, "class_of_sign");
-
-    /** */
-    public static final HqdmIri STATE_OF_PARTY = new HqdmIri(HQDM, "state_of_party");
-
-    /** */
-    public static final HqdmIri PARTY = new HqdmIri(HQDM, "party");
-
-    /** */
-    public static final HqdmIri STATE_OF_ORGANIZATION = new HqdmIri(HQDM, "state_of_organization");
-
-    /** */
-    public static final HqdmIri STATE_OF_LANGUAGE_COMMUNITY =
-            new HqdmIri(HQDM, "state_of_language_community");
-
-    /** */
-    public static final HqdmIri LANGUAGE_COMMUNITY = new HqdmIri(HQDM, "language_community");
-
-    /** */
-    public static final HqdmIri EMPLOYMENT = new HqdmIri(HQDM, "employment");
-
-    /** */
-    public static final HqdmIri STATE_OF_ORGANIZATION_COMPONENT =
-            new HqdmIri(HQDM, "state_of_organization_component");
-
-    /** */
-    public static final HqdmIri ORGANIZATION_COMPONENT =
-            new HqdmIri(HQDM, "organization_component");
-
-    /** */
-    public static final HqdmIri STATE_OF_POSITION = new HqdmIri(HQDM, "state_of_position");
-
-    /** */
-    public static final HqdmIri PERSON_IN_POSITION = new HqdmIri(HQDM, "person_in_position");
-
-    /** */
-    public static final HqdmIri POSITION = new HqdmIri(HQDM, "position");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_POSITION =
-            new HqdmIri(HQDM, "class_of_state_of_position");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PERSON_IN_POSITION =
-            new HqdmIri(HQDM, "class_of_person_in_position");
-
-    /** */
-    public static final HqdmIri CLASS_OF_POSITION = new HqdmIri(HQDM, "class_of_position");
-
-    /** */
-    public static final HqdmIri KIND_OF_POSITION = new HqdmIri(HQDM, "kind_of_position");
-
-    /** */
-    public static final HqdmIri STATE_OF_AMOUNT_OF_MONEY =
-            new HqdmIri(HQDM, "state_of_amount_of_money");
-
-    /** */
-    public static final HqdmIri AMOUNT_OF_MONEY = new HqdmIri(HQDM, "amount_of_money");
-
-    /** */
-    public static final HqdmIri MEMBER_OF_CURRENCY = new HqdmIri(HQDM, "member_of_currency");
-
-    /** */
-    public static final HqdmIri CURRENCY = new HqdmIri(HQDM, "currency");
-
-    /** */
-    public static final HqdmIri PRICE = new HqdmIri(HQDM, "price");
-
-    /** */
-    public static final HqdmIri OWNERSHIP = new HqdmIri(HQDM, "ownership");
-
-    /** */
-    public static final HqdmIri MONEY_ASSET = new HqdmIri(HQDM, "money_asset");
-
-    /** */
-    public static final HqdmIri ASSET = new HqdmIri(HQDM, "asset");
-
-    /** */
-    public static final HqdmIri TRANSFER_OF_OWNERSHIP = new HqdmIri(HQDM, "transfer_of_ownership");
-
-    /** */
-    public static final HqdmIri CAUSES_BEGINNING = new HqdmIri(HQDM, "causes_beginning");
-
-    /** */
-    public static final HqdmIri CAUSES_ENDING = new HqdmIri(HQDM, "causes_ending");
-
-    /** */
-    public static final HqdmIri TRANSFEROR = new HqdmIri(HQDM, "transferor");
-
-    /** */
-    public static final HqdmIri TRANSFEREE = new HqdmIri(HQDM, "transferee");
-
-    /** */
-    public static final HqdmIri TRANSFER_OF_OWNERSHIP_OF_MONEY =
-            new HqdmIri(HQDM, "transfer_of_ownership_of_money");
-
-    /** */
-    public static final HqdmIri REACHING_AGREEMENT = new HqdmIri(HQDM, "reaching_agreement");
-
-    /** */
-    public static final HqdmIri AGREEMENT_PROCESS = new HqdmIri(HQDM, "agreement_process");
-
-    /** */
-    public static final HqdmIri AGREEMENT_EXECUTION = new HqdmIri(HQDM, "agreement_execution");
-
-    /** */
-    public static final HqdmIri OFFER = new HqdmIri(HQDM, "offer");
-
-    /** */
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} that is the acceptance of an
+     * {@link uk.gov.gchq.hqdm.model.Offer} as {@link #PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.AgreeContract}.
+     */
     public static final HqdmIri ACCEPTANCE_OF_OFFER = new HqdmIri(HQDM, "acceptance_of_offer");
 
-    /** */
-    public static final HqdmIri CLASS_OF_REACHING_AGREEMENT =
-            new HqdmIri(HQDM, "class_of_reaching_agreement");
-
-    /** */
-    public static final HqdmIri CLASS_OF_AGREEMENT_PROCESS =
-            new HqdmIri(HQDM, "class_of_agreement_process");
-
-    /** */
-    public static final HqdmIri CLASS_OF_AGREEMENT_EXECUTION =
-            new HqdmIri(HQDM, "class_of_agreement_execution");
-
-    /** */
-    public static final HqdmIri CLASS_OF_OFFER = new HqdmIri(HQDM, "class_of_offer");
-
-    /** */
-    public static final HqdmIri AGREE_CONTRACT = new HqdmIri(HQDM, "agree_contract");
-
-    /** */
-    public static final HqdmIri CONTRACT_PROCESS = new HqdmIri(HQDM, "contract_process");
-
-    /** */
-    public static final HqdmIri CONTRACT_EXECUTION = new HqdmIri(HQDM, "contract_execution");
-
-    /** */
-    public static final HqdmIri CLASS_OF_AGREE_CONTRACT =
-            new HqdmIri(HQDM, "class_of_agree_contract");
-
-    /** */
-    public static final HqdmIri CLASS_OF_CONTRACT_PROCESS =
-            new HqdmIri(HQDM, "class_of_contract_process");
-
-    /** */
-    public static final HqdmIri CLASS_OF_CONTRACT_EXECUTION =
-            new HqdmIri(HQDM, "class_of_contract_execution");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF_ = new HqdmIri(HQDM, "consists_of_");
-
-    /** */
-    public static final HqdmIri OFFER_AND_ACCEPTANCE_FOR_GOODS =
-            new HqdmIri(HQDM, "offer_and_acceptance_for_goods");
-
-    /** */
-    public static final HqdmIri SALE_OF_GOODS = new HqdmIri(HQDM, "sale_of_goods");
-
-    /** */
-    public static final HqdmIri EXCHANGE_OF_GOODS_AND_MONEY =
-            new HqdmIri(HQDM, "exchange_of_goods_and_money");
-
-    /** */
-    public static final HqdmIri OFFER_FOR_GOODS = new HqdmIri(HQDM, "offer_for_goods");
-
-    /** */
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ReachingAgreement} that consists of one or more
+     * {@link uk.gov.gchq.hqdm.model.Offer}s of a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnershipOfMoney} for a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} of goods where one
+     * {@link uk.gov.gchq.hqdm.model.Offer} is accepted.
+     */
     public static final HqdmIri ACCEPTANCE_OF_OFFER_FOR_GOODS =
             new HqdmIri(HQDM, "acceptance_of_offer_for_goods");
 
-    /** */
-    public static final HqdmIri STATE_OF_SALES_PRODUCT_INSTANCE =
-            new HqdmIri(HQDM, "state_of_sales_product_instance");
-
-    /** */
-    public static final HqdmIri SALES_PRODUCT_INSTANCE =
-            new HqdmIri(HQDM, "sales_product_instance");
-
-    /** */
-    public static final HqdmIri PRODUCT_BRAND = new HqdmIri(HQDM, "product_brand");
-
-    /** */
-    public static final HqdmIri ROLES = new HqdmIri(HQDM, "roles");
-
-    /** */
-    public static final HqdmIri AGGREGATED_INTO = new HqdmIri(HQDM, "aggregated_into");
-
-    /** */
-    public static final HqdmIri BEGINNING = new HqdmIri(HQDM, "beginning");
-
-    /** */
-    public static final HqdmIri CAUSES = new HqdmIri(HQDM, "causes");
-
-    /** */
-    public static final HqdmIri CONSISTS_OF = new HqdmIri(HQDM, "consists_of");
-
-    /** */
-    public static final HqdmIri ENDING = new HqdmIri(HQDM, "ending");
-
-    /** */
-    public static final HqdmIri HAS_CLASS_MEMBER = new HqdmIri(HQDM, "has_class_member");
-
-    /** */
-    public static final HqdmIri HAS_SUPERCLASS = new HqdmIri(HQDM, "has_superclass");
-
-    /** */
-    public static final HqdmIri MEMBER_OF = new HqdmIri(HQDM, "member_of");
-
-    /** */
-    public static final HqdmIri MEMBER_OF_KIND = new HqdmIri(HQDM, "member_of_kind");
-
-    /** */
-    public static final HqdmIri PARTICIPANT_IN = new HqdmIri(HQDM, "participant_in");
-
-    /** */
-    public static final HqdmIri PART_OF = new HqdmIri(HQDM, "part_of");
-
-    /** */
-    public static final HqdmIri PART_OF_ = new HqdmIri(HQDM, "part_of_");
-
-    /** */
-    public static final HqdmIri PART_OF_POSSIBLE_WORLD =
-            new HqdmIri(HQDM, "part_of_possible_world");
-
-    /** */
-    public static final HqdmIri REFERENCES = new HqdmIri(HQDM, "references");
-
-    /** */
-    public static final HqdmIri REPRESENTS = new HqdmIri(HQDM, "represents");
-
-    /** */
-    public static final HqdmIri TEMPORAL_PART_OF = new HqdmIri(HQDM, "temporal_part_of");
-
-    /** */
-    public static final HqdmIri REQUIRED_ROLE_PLAYER = new HqdmIri(HQDM, "required_role_player");
-
-    /** */
-    public static final HqdmIri INVOLVES = new HqdmIri(HQDM, "involves");
-
-    /** */
-    public static final HqdmIri STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "state_of_biological_system_component");
-
-    /** */
-    public static final HqdmIri UNIT_OF_MEASURE = new HqdmIri(HQDM, "unit_of_measure");
-
-    /** */
-    public static final HqdmIri STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
-            new HqdmIri(HQDM, "state_of_socially_constructed_activity");
-
-    /** */
-    public static final HqdmIri STATE_OF_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_physical_object");
-
-    /** */
-    public static final HqdmIri STATE_OF_ORDINARY_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "state_of_ordinary_physical_object");
-
-    /** */
-    public static final HqdmIri STATE_OF_ASSOCIATION = new HqdmIri(HQDM, "state_of_association");
-
-    /** */
-    public static final HqdmIri STATE_OF_ACTIVITY = new HqdmIri(HQDM, "state_of_activity");
-
-    /** */
-    public static final HqdmIri STATE = new HqdmIri(HQDM, "state");
-
-    /** */
-    public static final HqdmIri SOCIALLY_CONSTRUCTED_ACTIVITY =
-            new HqdmIri(HQDM, "socially_constructed_activity");
-
-    /** */
-    public static final HqdmIri SCALE = new HqdmIri(HQDM, "scale");
-
-    /** */
-    public static final HqdmIri REQUIREMENT_SPECIFICATION =
-            new HqdmIri(HQDM, "requirement_specification");
-
-    /** */
-    public static final HqdmIri RELATIONSHIP = new HqdmIri(HQDM, "relationship");
-
-    /** */
-    public static final HqdmIri PLAN = new HqdmIri(HQDM, "plan");
-
-    /** */
-    public static final HqdmIri PHYSICAL_QUANTITY = new HqdmIri(HQDM, "physical_quantity");
-
-    /** */
-    public static final HqdmIri PHYSICAL_PROPERTY_RANGE =
-            new HqdmIri(HQDM, "physical_property_range");
-
-    /** */
-    public static final HqdmIri PHYSICAL_PROPERTY = new HqdmIri(HQDM, "physical_property");
-
-    /** */
-    public static final HqdmIri PHYSICAL_OBJECT = new HqdmIri(HQDM, "physical_object");
-
-    /** */
-    public static final HqdmIri PERIOD_OF_TIME = new HqdmIri(HQDM, "period_of_time");
-
-    /** */
-    public static final HqdmIri ORDINARY_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "ordinary_physical_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_SYSTEM = new HqdmIri(HQDM, "kind_of_system");
-
-    /** */
-    public static final HqdmIri KIND_OF_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "kind_of_system_component");
-
-    /** */
-    public static final HqdmIri KIND_OF_SOCIALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "kind_of_socially_constructed_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_RELATIONSHIP_WITH_SIGNATURE =
-            new HqdmIri(HQDM, "kind_of_relationship_with_signature");
-
-    /** */
-    public static final HqdmIri KIND_OF_RELATIONSHIP_WITH_RESTRICTION =
-            new HqdmIri(HQDM, "kind_of_relationship_with_restriction");
-
-    /** */
-    public static final HqdmIri KIND_OF_PHYSICAL_QUANTITY =
-            new HqdmIri(HQDM, "kind_of_physical_quantity");
-
-    /** */
-    public static final HqdmIri KIND_OF_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_physical_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_PHYSICAL_PROPERTY =
-            new HqdmIri(HQDM, "kind_of_physical_property");
-
-    /** */
-    public static final HqdmIri KIND_OF_ORGANIZATION_COMPONENT =
-            new HqdmIri(HQDM, "kind_of_organization_component");
-
-    /** */
-    public static final HqdmIri KIND_OF_PARTY = new HqdmIri(HQDM, "kind_of_party");
-
-    /** */
-    public static final HqdmIri KIND_OF_ORDINARY_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_ordinary_physical_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_ORDINARY_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_ordinary_functional_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "kind_of_intentionally_constructed_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_ORDINARY_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_ordinary_biological_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_FUNCTIONAL_SYSTEM =
-            new HqdmIri(HQDM, "kind_of_functional_system");
-
-    /** */
-    public static final HqdmIri KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "kind_of_functional_system_component");
-
-    /** */
-    public static final HqdmIri KIND_OF_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_functional_object");
-
-    /** */
-    public static final HqdmIri KIND_OF_BIOLOGICAL_SYSTEM =
-            new HqdmIri(HQDM, "kind_of_biological_system");
-
-    /** */
-    public static final HqdmIri KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "kind_of_biological_system_component");
-
-    /** */
-    public static final HqdmIri KIND_OF_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "kind_of_biological_object");
-
-    /** */
-    public static final HqdmIri INDIVIDUAL = new HqdmIri(HQDM, "individual");
-
-    /** */
-    public static final HqdmIri IDENTIFICATION_OF_PHYSICAL_QUANTITY =
-            new HqdmIri(HQDM, "identification_of_physical_quantity");
-
-    /** */
-    public static final HqdmIri FUNCTION_ = new HqdmIri(HQDM, "function_");
-
-    /** */
-    public static final HqdmIri EVENT = new HqdmIri(HQDM, "event");
-
-    /** */
-    public static final HqdmIri DEFINED_RELATIONSHIP = new HqdmIri(HQDM, "defined_relationship");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SYSTEM =
-            new HqdmIri(HQDM, "class_of_state_of_system");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_SYSTEM_COMPONENT =
-            new HqdmIri(HQDM, "class_of_state_of_system_component");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_physical_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_ordinary_physical_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_ordinary_functional_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_ordinary_biological_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_intentionally_constructed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_functional_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_state_of_biological_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ASSOCIATION =
-            new HqdmIri(HQDM, "class_of_state_of_association");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_AMOUNT_OF_MONEY =
-            new HqdmIri(HQDM, "class_of_state_of_amount_of_money");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE_OF_ACTIVITY =
-            new HqdmIri(HQDM, "class_of_state_of_activity");
-
-    /** */
-    public static final HqdmIri CLASS_OF_STATE = new HqdmIri(HQDM, "class_of_state");
-
-    /** */
-    public static final HqdmIri CLASS_OF_SPATIO_TEMPORAL_EXTENT =
-            new HqdmIri(HQDM, "class_of_spatio_temporal_extent");
-
-    /** */
-    public static final HqdmIri CLASS_OF_RELATIONSHIP = new HqdmIri(HQDM, "class_of_relationship");
-
-    /** */
-    public static final HqdmIri CLASS_OF_POINT_IN_TIME =
-            new HqdmIri(HQDM, "class_of_point_in_time");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PHYSICAL_QUANTITY =
-            new HqdmIri(HQDM, "class_of_physical_quantity");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PHYSICAL_PROPERTY =
-            new HqdmIri(HQDM, "class_of_physical_property");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_physical_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PERIOD_OF_TIME =
-            new HqdmIri(HQDM, "class_of_period_of_time");
-
-    /** */
-    public static final HqdmIri CLASS_OF_PARTICIPANT = new HqdmIri(HQDM, "class_of_participant");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ORDINARY_PHYSICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_ordinary_physical_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ORDINARY_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_ordinary_functional_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ORDINARY_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_ordinary_biological_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
-            new HqdmIri(HQDM, "class_of_intentionally_constructed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_INSTALLED_OBJECT =
-            new HqdmIri(HQDM, "class_of_installed_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_INDIVIDUAL = new HqdmIri(HQDM, "class_of_individual");
-
-    /** */
-    public static final HqdmIri CLASS_OF_EVENT = new HqdmIri(HQDM, "class_of_event");
-
-    /** */
-    public static final HqdmIri CLASS_OF_FUNCTIONAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_functional_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_CLASS_OF_SPATIO_TEMPORAL_EXTENT =
-            new HqdmIri(HQDM, "class_of_class_of_spatio_temporal_extent");
-
-    /** */
-    public static final HqdmIri CLASS_OF_CLASS = new HqdmIri(HQDM, "class_of_class");
-
-    /** */
-    public static final HqdmIri CLASS_OF_BIOLOGICAL_OBJECT =
-            new HqdmIri(HQDM, "class_of_biological_object");
-
-    /** */
-    public static final HqdmIri CLASS_OF_ASSOCIATION = new HqdmIri(HQDM, "class_of_association");
-
-    /** */
-    public static final HqdmIri CLASS_OF_AMOUNT_OF_MONEY =
-            new HqdmIri(HQDM, "class_of_amount_of_money");
-
-    /** */
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Individual} that consists of its
+     * {@link uk.gov.gchq.hqdm.model.Participant}s and causes some
+     * {@link uk.gov.gchq.hqdm.model.Event}.
+     */
+    public static final HqdmIri ACTIVITY = new HqdmIri(HQDM, "activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Relationship} where the whole is at least the sum of the
+     * parts.
+     */
+    public static final HqdmIri AGGREGATION = new HqdmIri(HQDM, "aggregation");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ReachingAgreement} that consists of an
+     * {@link uk.gov.gchq.hqdm.model.Offer} of some {@link uk.gov.gchq.hqdm.model.Thing} in exchange
+     * for some consideration, and an {@link uk.gov.gchq.hqdm.model.AcceptanceOfOffer}.
+     */
+    public static final HqdmIri AGREE_CONTRACT = new HqdmIri(HQDM, "agree_contract");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} where two or more parties carry
+     * out a course of action previously agreed upon.
+     */
+    public static final HqdmIri AGREEMENT_EXECUTION = new HqdmIri(HQDM, "agreement_execution");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} that consists of a
+     * {@link uk.gov.gchq.hqdm.model.ReachingAgreement} and an
+     * {@link uk.gov.gchq.hqdm.model.AgreementExecution}, where the
+     * {@link uk.gov.gchq.hqdm.model.AgreementExecution} is the course of action agreed to in the
+     * {@link uk.gov.gchq.hqdm.model.ReachingAgreement}.
+     */
+    public static final HqdmIri AGREEMENT_PROCESS = new HqdmIri(HQDM, "agreement_process");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfAmountOfMoney}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} that is intended and accepted for use as a
+     * means of exchange.
+     */
+    public static final HqdmIri AMOUNT_OF_MONEY = new HqdmIri(HQDM, "amount_of_money");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.Participant} that is the {@link #PARTICIPANT_IN} an
+     * {@link uk.gov.gchq.hqdm.model.Ownership} that is owned.
+     */
+    public static final HqdmIri ASSET = new HqdmIri(HQDM, "asset");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Individual} that {@link #CONSISTS_OF} the
+     * {@link uk.gov.gchq.hqdm.model.Participant}s that are associated, and where the
+     * {@link uk.gov.gchq.hqdm.model.Participant}s are {@link #PART_OF} the same
+     * {@link uk.gov.gchq.hqdm.model.PeriodOfTime}.
+     */
+    public static final HqdmIri ASSOCIATION = new HqdmIri(HQDM, "association");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Event} that is the {@link #BEGINNING} of an
+     * {@link uk.gov.gchq.hqdm.model.Ownership}.
+     */
+    public static final HqdmIri BEGINNING_OF_OWNERSHIP =
+            new HqdmIri(HQDM, "beginning_of_ownership");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfBiologicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} that sustains itself and reproduces.
+     */
+    public static final HqdmIri BIOLOGICAL_OBJECT = new HqdmIri(HQDM, "biological_object");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.System} that is also an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryBiologicalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystem}.
+     */
+    public static final HqdmIri BIOLOGICAL_SYSTEM = new HqdmIri(HQDM, "biological_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.BiologicalObject},
+     * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystemComponent} and
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} that is any
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent}.
+     */
+    public static final HqdmIri BIOLOGICAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "biological_system_component");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AbstractObject} that has members and whose identity is
+     * defined by its membership.
+     */
+    public static final HqdmIri CLASS = new HqdmIri(HQDM, "class");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Relationship} where a {@link uk.gov.gchq.hqdm.model.Thing} is
+     * a member of a class{@link uk.gov.gchq.hqdm.model.Class}.
+     */
+    public static final HqdmIri CLASSIFICATION = new HqdmIri(HQDM, "classification");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Class} that is {@link uk.gov.gchq.hqdm.model.AbstractObject}
+     * or any its subsets.
+     */
     public static final HqdmIri CLASS_OF_ABSTRACT_OBJECT =
             new HqdmIri(HQDM, "class_of_abstract_object");
 
-    /** */
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.Activity} or any of its possible subsets.
+     */
+    public static final HqdmIri CLASS_OF_ACTIVITY = new HqdmIri(HQDM, "class_of_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfReachingAgreement} that is
+     * {@link uk.gov.gchq.hqdm.model.AgreeContract} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_AGREE_CONTRACT =
+            new HqdmIri(HQDM, "class_of_agree_contract");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.AgreementExecution} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_AGREEMENT_EXECUTION =
+            new HqdmIri(HQDM, "class_of_agreement_execution");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.AgreementProcess} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_AGREEMENT_PROCESS =
+            new HqdmIri(HQDM, "class_of_agreement_process");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfAmountOfMoney}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.AmountOfMoney} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_AMOUNT_OF_MONEY =
+            new HqdmIri(HQDM, "class_of_amount_of_money");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfAssociation} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} that is
+     * {@link uk.gov.gchq.hqdm.model.Association} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ASSOCIATION = new HqdmIri(HQDM, "class_of_association");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalSystem},
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryBiologicalObject}, and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystem} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_BIOLOGICAL_SYSTEM =
+            new HqdmIri(HQDM, "class_of_biological_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalObject},
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalSystemComponent}, and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSystemComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystemComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_BIOLOGICAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_biological_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Class} that is {@link uk.gov.gchq.hqdm.model.Class} or any of
+     * its subsets.
+     */
+    public static final HqdmIri CLASS_OF_CLASS = new HqdmIri(HQDM, "class_of_class");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfClass} that is
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_CLASS_OF_SPATIO_TEMPORAL_EXTENT =
+            new HqdmIri(HQDM, "class_of_class_of_spatio_temporal_extent");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAgreementExecution} that is
+     * {@link uk.gov.gchq.hqdm.model.ContractExecution} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_CONTRACT_EXECUTION =
+            new HqdmIri(HQDM, "class_of_contract_execution");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAgreementProcess} that is
+     * {@link uk.gov.gchq.hqdm.model.ContractProcess} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_CONTRACT_PROCESS =
+            new HqdmIri(HQDM, "class_of_contract_process");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} that is
+     * {@link uk.gov.gchq.hqdm.model.Event} or any of its possible subsets.
+     */
+    public static final HqdmIri CLASS_OF_EVENT = new HqdmIri(HQDM, "class_of_event");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject},
+     * {@link uk.gov.gchq.hqdm.model.ClassOfIntentionallyConstructedObject}, and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfFunctionalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.FunctionalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfFunctionalSystem}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryFunctionalObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.FunctionalSystem} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_FUNCTIONAL_SYSTEM =
+            new HqdmIri(HQDM, "class_of_functional_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfFunctionalSystemComponent}, and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSystemComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.FunctionalSystemComponent} and any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.Individual} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_INDIVIDUAL = new HqdmIri(HQDM, "class_of_individual");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalSystemComponent}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryBiologicalObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfInstalledObject} that is
+     * {@link uk.gov.gchq.hqdm.model.InPlaceBiologicalComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_IN_PLACE_BIOLOGICAL_COMPONENT =
+            new HqdmIri(HQDM, "class_of_in_place_biological_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfFunctionalSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfInstalledObject} that is
+     * {@link uk.gov.gchq.hqdm.model.InstalledFunctionalSystemComponent} and any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_installed_functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.InstalledObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_INSTALLED_OBJECT =
+            new HqdmIri(HQDM, "class_of_installed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfIntentionallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "class_of_intentionally_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.Offer} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_OFFER = new HqdmIri(HQDM, "class_of_offer");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalObject},
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryPhysicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryBiologicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryBiologicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ORDINARY_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_ordinary_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryFunctionalObject}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfFunctionalObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryFunctionalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ORDINARY_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_ordinary_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ORDINARY_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_ordinary_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrganization}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfParty} that is
+     * {@link uk.gov.gchq.hqdm.model.Organization} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ORGANIZATION = new HqdmIri(HQDM, "class_of_organization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrganizationComponent}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSystemComponent}, and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.OrganizationComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_ORGANIZATION_COMPONENT =
+            new HqdmIri(HQDM, "class_of_organization_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.Participant} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PARTICIPANT = new HqdmIri(HQDM, "class_of_participant");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSystem} that is {@link uk.gov.gchq.hqdm.model.Party}
+     * or any of its subtypes.
+     */
+    public static final HqdmIri CLASS_OF_PARTY = new HqdmIri(HQDM, "class_of_party");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.PeriodOfTime} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PERIOD_OF_TIME =
+            new HqdmIri(HQDM, "class_of_period_of_time");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalSystem},
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPerson} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfParty} that is {@link uk.gov.gchq.hqdm.model.Person} or
+     * any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PERSON = new HqdmIri(HQDM, "class_of_person");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfInstalledObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPosition} that is
+     * {@link uk.gov.gchq.hqdm.model.PersonInPosition} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PERSON_IN_POSITION =
+            new HqdmIri(HQDM, "class_of_person_in_position");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} and a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfClassOfSpatioTemporalExtent} that is
+     * {@link uk.gov.gchq.hqdm.model.PhysicalProperty} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PHYSICAL_PROPERTY =
+            new HqdmIri(HQDM, "class_of_physical_property");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalProperty} that is
+     * {@link uk.gov.gchq.hqdm.model.PhysicalQuantity} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_PHYSICAL_QUANTITY =
+            new HqdmIri(HQDM, "class_of_physical_quantity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfEvent} that is
+     * {@link uk.gov.gchq.hqdm.model.PointInTime} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_POINT_IN_TIME =
+            new HqdmIri(HQDM, "class_of_point_in_time");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPosition} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrganizationComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.Position} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_POSITION = new HqdmIri(HQDM, "class_of_position");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfPeriodOfTime} that is
+     * {@link uk.gov.gchq.hqdm.model.PossibleWorld} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_POSSIBLE_WORLD =
+            new HqdmIri(HQDM, "class_of_possible_world");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.ReachingAgreement} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_REACHING_AGREEMENT =
+            new HqdmIri(HQDM, "class_of_reaching_agreement");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Class} that is {@link uk.gov.gchq.hqdm.model.Relationship} or
+     * any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_RELATIONSHIP = new HqdmIri(HQDM, "class_of_relationship");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAssociation} that is
+     * {@link uk.gov.gchq.hqdm.model.RepresentationBySign} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_REPRESENTATION =
+            new HqdmIri(HQDM, "class_of_representation");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSalesProductInstance} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryFunctionalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.SalesProductInstance} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SALES_PRODUCT_INSTANCE =
+            new HqdmIri(HQDM, "class_of_sales_product_instance");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSign} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.Sign} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SIGN = new HqdmIri(HQDM, "class_of_sign");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfActivity} that is
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
+            new HqdmIri(HQDM, "class_of_socially_constructed_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIntentionallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SOCIALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "class_of_socially_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Class} that is
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SPATIO_TEMPORAL_EXTENT =
+            new HqdmIri(HQDM, "class_of_spatio_temporal_extent");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} that is
+     * {@link uk.gov.gchq.hqdm.model.State} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE = new HqdmIri(HQDM, "class_of_state");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfActivity} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ACTIVITY =
+            new HqdmIri(HQDM, "class_of_state_of_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSociallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfAmountOfMoney} or one of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_AMOUNT_OF_MONEY =
+            new HqdmIri(HQDM, "class_of_state_of_amount_of_money");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfAssociation} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ASSOCIATION =
+            new HqdmIri(HQDM, "class_of_state_of_association");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryBiologicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystem} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM =
+            new HqdmIri(HQDM, "class_of_state_of_biological_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystemComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystemComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_state_of_biological_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfIntentionallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfFunctionalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryFunctionalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfFunctionalSystem} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM =
+            new HqdmIri(HQDM, "class_of_state_of_functional_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryFunctionalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystemComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfFunctionalSystemComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_state_of_functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfIntentionallyConstructedObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_intentionally_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_ordinary_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfFunctionalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryFunctionalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_ordinary_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ORDINARY_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_ordinary_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSociallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfParty} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrganization} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ORGANIZATION =
+            new HqdmIri(HQDM, "class_of_state_of_organization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSociallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrganizationComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_ORGANIZATION_COMPONENT =
+            new HqdmIri(HQDM, "class_of_state_of_organization_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfParty} or any of its subtypes.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_PARTY =
+            new HqdmIri(HQDM, "class_of_state_of_party");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfBiologicalSystem} and
+     * {@link uk.gov.gchq.hqdm.model.ClassOfStateOfParty} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfPerson} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_PERSON =
+            new HqdmIri(HQDM, "class_of_state_of_person");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrganizationComponent} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfPosition} and any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_POSITION =
+            new HqdmIri(HQDM, "class_of_state_of_position");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryFunctionalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSalesProductInstance} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SALES_PRODUCT_INSTANCE =
+            new HqdmIri(HQDM, "class_of_state_of_sales_product_instance");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSociallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSign} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SIGN =
+            new HqdmIri(HQDM, "class_of_state_of_sign");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSociallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
+            new HqdmIri(HQDM, "class_of_state_of_socially_constructed_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfIntentionallyConstructedObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} or one of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "class_of_state_of_socially_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystem} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SYSTEM =
+            new HqdmIri(HQDM, "class_of_state_of_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystemComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_STATE_OF_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_state_of_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystem} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.System} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SYSTEM = new HqdmIri(HQDM, "class_of_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfStateOfSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject} that is
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} or any of its subsets.
+     */
+    public static final HqdmIri CLASS_OF_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "class_of_system_component");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Aggregation} where the {@link #WHOLE} is an arrangement of
+     * the parts that results in emergent properties.
+     */
+    public static final HqdmIri COMPOSITION = new HqdmIri(HQDM, "composition");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AgreementExecution} that is the provision of some
+     * {@link uk.gov.gchq.hqdm.model.Thing} in exchange for some consideration.
+     */
+    public static final HqdmIri CONTRACT_EXECUTION = new HqdmIri(HQDM, "contract_execution");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AgreementProcess} that consists of an
+     * {@link uk.gov.gchq.hqdm.model.AgreeContract} and a
+     * {@link uk.gov.gchq.hqdm.model.ContractExecution}.
+     */
+    public static final HqdmIri CONTRACT_PROCESS = new HqdmIri(HQDM, "contract_process");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAmountOfMoney} that is the subset of
+     * {@link uk.gov.gchq.hqdm.model.AmountOfMoney} that has as members all the money issued by an
+     * issuing authority.
+     */
+    public static final HqdmIri CURRENCY = new HqdmIri(HQDM, "currency");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Relationship} that is defined by a
+     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
+     */
+    public static final HqdmIri DEFINED_RELATIONSHIP = new HqdmIri(HQDM, "defined_relationship");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} that defines a
+     * {@link uk.gov.gchq.hqdm.model.Class}.
+     */
+    public static final HqdmIri DEFINITION = new HqdmIri(HQDM, "definition");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} that describes some
+     * {@link uk.gov.gchq.hqdm.model.Thing}.
+     */
+    public static final HqdmIri DESCRIPTION = new HqdmIri(HQDM, "description");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPerson} that is a {@link #PARTICIPANT_IN} an
+     * {@link uk.gov.gchq.hqdm.model.Employment}.
+     */
+    public static final HqdmIri EMPLOYEE = new HqdmIri(HQDM, "employee");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} that is a {@link #PARTICIPANT_IN} an
+     * {@link uk.gov.gchq.hqdm.model.Employment}.
+     */
+    public static final HqdmIri EMPLOYER = new HqdmIri(HQDM, "employer");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Association} that consists of an
+     * {@link uk.gov.gchq.hqdm.model.Employer} and an {@link uk.gov.gchq.hqdm.model.Employee} where
+     * the {@link uk.gov.gchq.hqdm.model.Employer} pays the {@link uk.gov.gchq.hqdm.model.Employee}
+     * to work for them.
+     */
+    public static final HqdmIri EMPLOYMENT = new HqdmIri(HQDM, "employment");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Event} that is the {@link #ENDING} of an
+     * {@link uk.gov.gchq.hqdm.model.Ownership}.
+     */
+    public static final HqdmIri ENDING_OF_OWNERSHIP = new HqdmIri(HQDM, "ending_of_ownership");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Class} where each {@link #MEMBER__OF} the
+     * {@link uk.gov.gchq.hqdm.model.Class} is known.
+     */
+    public static final HqdmIri ENUMERATED_CLASS = new HqdmIri(HQDM, "enumerated_class");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} that has zero temporal thickness and
+     * may bound some {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent}.
+     */
+    public static final HqdmIri EVENT = new HqdmIri(HQDM, "event");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AgreementExecution} that consists of a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} of goods and a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnershipOfMoney}.
+     */
+    public static final HqdmIri EXCHANGE_OF_GOODS_AND_MONEY =
+            new HqdmIri(HQDM, "exchange_of_goods_and_money");
+
+    /**
+     * A one-to-many {@link uk.gov.gchq.hqdm.model.Relationship}.
+     */
+    public static final HqdmIri FUNCTION_ = new HqdmIri(HQDM, "function_");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} that has an {@link #INTENDED_ROLE}.
+     */
+    public static final HqdmIri FUNCTIONAL_OBJECT = new HqdmIri(HQDM, "functional_object");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.StateOfFunctionalSystem} that is also an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryFunctionalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.System}.
+     */
+    public static final HqdmIri FUNCTIONAL_SYSTEM = new HqdmIri(HQDM, "functional_system");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject} that is a replaceable
+     * {@link #COMPONENT_OF} a {@link uk.gov.gchq.hqdm.model.FunctionalSystem}.
+     */
+    public static final HqdmIri FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} that is a surrogate for the
+     * {@link uk.gov.gchq.hqdm.model.Thing} {@link #REPRESENTED}.
+     */
+    public static final HqdmIri IDENTIFICATION = new HqdmIri(HQDM, "identification");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Identification} that identifies a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalQuantity}. An
+     * {@link uk.gov.gchq.hqdm.model.IdentificationOfPhysicalQuantity} consists of a REAL that is a
+     * representation of the {@link #VALUE_} the physical quantity maps to on the
+     * {@link uk.gov.gchq.hqdm.model.Scale}.
+     */
+    public static final HqdmIri IDENTIFICATION_OF_PHYSICAL_QUANTITY =
+            new HqdmIri(HQDM, "identification_of_physical_quantity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} that is not a proper
+     * {@link #TEMPORAL_PART_OF} any other {@link uk.gov.gchq.hqdm.model.Individual} of the same
+     * kind.
+     */
+    public static final HqdmIri INDIVIDUAL = new HqdmIri(HQDM, "individual");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.InstalledObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystemComponent}.
+     */
+    public static final HqdmIri IN_PLACE_BIOLOGICAL_COMPONENT =
+            new HqdmIri(HQDM, "in_place_biological_component");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.InstalledObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryFunctionalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.StateOfFunctionalSystemComponent}.
+     */
+    public static final HqdmIri INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "installed_functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystemComponent} that is a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} from when it is installed as a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} to when it is removed.
+     */
+    public static final HqdmIri INSTALLED_OBJECT = new HqdmIri(HQDM, "installed_object");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Individual} and
+     * {@link uk.gov.gchq.hqdm.model.StateOfIntentionallyConstructedObject} that is intentionally
+     * constructed.
+     */
+    public static final HqdmIri INTENTIONALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "intentionally_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfActivity} all of whose members are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ACTIVITY = new HqdmIri(HQDM, "kind_of_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAssociation} where all the members are of the same
+     * kind.
+     */
+    public static final HqdmIri KIND_OF_ASSOCIATION = new HqdmIri(HQDM, "kind_of_association");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalObject} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfBiologicalObject} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalSystem} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystem} all of whose members have a natural
+     * {@link uk.gov.gchq.hqdm.model.Role} that they play.
+     */
+    public static final HqdmIri KIND_OF_BIOLOGICAL_SYSTEM =
+            new HqdmIri(HQDM, "kind_of_biological_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfBiologicalSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystemComponent} where all the member components play the
+     * same {@link uk.gov.gchq.hqdm.model.Role} in some
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystem}.
+     */
+    public static final HqdmIri KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "kind_of_biological_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfFunctionalObject}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.KindOfIntentionallyConstructedObject} where each
+     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.KindOfFunctionalObject} is of the same
+     * kind.
+     */
+    public static final HqdmIri KIND_OF_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfFunctionalSystem} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystem} where each
+     * {@link uk.gov.gchq.hqdm.model.KindOfFunctionalSystem} has members that are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_FUNCTIONAL_SYSTEM =
+            new HqdmIri(HQDM, "kind_of_functional_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfFunctionalSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystemComponent} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfFunctionalSystemComponent} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "kind_of_functional_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} where all the members possess attributes
+     * in common.
+     */
+    public static final HqdmIri KIND_OF_INDIVIDUAL = new HqdmIri(HQDM, "kind_of_individual");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfIntentionallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfIndividual} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfIntentionallyConstructedObject} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "kind_of_intentionally_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryBiologicalObject} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrdinaryPhysicalObject} and a
+     * {@link uk.gov.gchq.hqdm.model.KindOfBiologicalObject} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrdinaryBiologicalObject} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ORDINARY_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_ordinary_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryBiologicalObject}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrdinaryPhysicalObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.KindOfBiologicalObject} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrdinaryBiologicalObject} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ORDINARY_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_ordinary_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalObject} where each
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} has members that are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ORDINARY_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_ordinary_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOrdinaryPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalObject} where each
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} has members that are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ORGANIZATION = new HqdmIri(HQDM, "kind_of_organization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOrganizationComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystemComponent} whose members are all of the same kind.
+     */
+    public static final HqdmIri KIND_OF_ORGANIZATION_COMPONENT =
+            new HqdmIri(HQDM, "kind_of_organization_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfParty} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystem} where all the members are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_PARTY = new HqdmIri(HQDM, "kind_of_party");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPerson} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfParty} whose members are all of the same kind.
+     */
+    public static final HqdmIri KIND_OF_PERSON = new HqdmIri(HQDM, "kind_of_person");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfIndividual} where each
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} has members that are of the same kind.
+     */
+    public static final HqdmIri KIND_OF_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "kind_of_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalProperty} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalProperty} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_PHYSICAL_PROPERTY =
+            new HqdmIri(HQDM, "kind_of_physical_property");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPhysicalQuantity} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalProperty} such that each {@link #MEMBER_OF} the
+     * same {@link uk.gov.gchq.hqdm.model.KindOfPhysicalQuantity} is comparable to the others.
+     */
+    public static final HqdmIri KIND_OF_PHYSICAL_QUANTITY =
+            new HqdmIri(HQDM, "kind_of_physical_quantity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfPosition} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrganizationComponent} where all the members are of the
+     * same kind.
+     */
+    public static final HqdmIri KIND_OF_POSITION = new HqdmIri(HQDM, "kind_of_position");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature} where one or more
+     * {@link #ROLES} have fixed players.
+     */
+    public static final HqdmIri KIND_OF_RELATIONSHIP_WITH_RESTRICTION =
+            new HqdmIri(HQDM, "kind_of_relationship_with_restriction");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfRelationship} that is a subset of
+     * {@link uk.gov.gchq.hqdm.model.DefinedRelationship} type where the
+     * {@link uk.gov.gchq.hqdm.model.Classification}s involved in each
+     * {@link uk.gov.gchq.hqdm.model.DefinedRelationship} have as {@link #CLASSIFIER}s the
+     * {@link #ROLES} specified by the
+     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
+     */
+    public static final HqdmIri KIND_OF_RELATIONSHIP_WITH_SIGNATURE =
+            new HqdmIri(HQDM, "kind_of_relationship_with_signature");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfIntentionallyConstructedObject} where each
+     * {@link uk.gov.gchq.hqdm.model.KindOfSociallyConstructedObject} has members that are of the
+     * same kind.
+     */
+    public static final HqdmIri KIND_OF_SOCIALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "kind_of_socially_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSystem} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfOrdinaryPhysicalObject} where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystem} is of the same kind.
+     */
+    public static final HqdmIri KIND_OF_SYSTEM = new HqdmIri(HQDM, "kind_of_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalObject} where all the members are of the same
+     * kind.
+     */
+    public static final HqdmIri KIND_OF_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "kind_of_system_component");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Organization} that is a group of people who share a common
+     * understanding of a set of {@link uk.gov.gchq.hqdm.model.Sign}s.
+     */
+    public static final HqdmIri LANGUAGE_COMMUNITY = new HqdmIri(HQDM, "language_community");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Asset} that is a
+     * {@link uk.gov.gchq.hqdm.model.StateOfAmountOfMoney}.
+     */
+    public static final HqdmIri MONEY_ASSET = new HqdmIri(HQDM, "money_asset");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} that proposes an exchange of
+     * some {@link uk.gov.gchq.hqdm.model.Thing} for some consideration.
+     */
+    public static final HqdmIri OFFER = new HqdmIri(HQDM, "offer");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ReachingAgreement} that {@link #CONSISTS_OF} exactly one
+     * {@link uk.gov.gchq.hqdm.model.Offer} of a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnershipOfMoney} for exactly one
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} that is accepted.
+     */
+    public static final HqdmIri OFFER_AND_ACCEPTANCE_FOR_GOODS =
+            new HqdmIri(HQDM, "offer_and_acceptance_for_goods");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Offer} of an
+     * {@link uk.gov.gchq.hqdm.model.ExchangeOfGoodsAndMoney}.
+     */
+    public static final HqdmIri OFFER_FOR_GOODS = new HqdmIri(HQDM, "offer_for_goods");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfOffer} that is for a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfIndividual}, at a {@link uk.gov.gchq.hqdm.model.Price},
+     * by a {@link uk.gov.gchq.hqdm.model.Party}, for a {@link uk.gov.gchq.hqdm.model.PeriodOfTime}.
+     */
+    public static final HqdmIri OFFERING = new HqdmIri(HQDM, "offering");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject}, a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject}, and an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject} that does not survive the replacement of all
+     * of its parts.
+     */
+    public static final HqdmIri ORDINARY_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "ordinary_biological_object");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryFunctionalObject} and
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.FunctionalObject}.
+     */
+    public static final HqdmIri ORDINARY_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "ordinary_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.PhysicalObject} that does not survive changing all its parts
+     * at once.
+     */
+    public static final HqdmIri ORDINARY_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "ordinary_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrganization}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.Party}, and a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} that is an organized body of people.
+     */
+    public static final HqdmIri ORGANIZATION = new HqdmIri(HQDM, "organization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrganizationComponent},
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent}, and
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} that is a {@link #COMPONENT_OF} an
+     * {@link uk.gov.gchq.hqdm.model.Organization} that can be completely replaced without losing
+     * its identity.
+     */
+    public static final HqdmIri ORGANIZATION_COMPONENT =
+            new HqdmIri(HQDM, "organization_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} that is also a
+     * {@link uk.gov.gchq.hqdm.model.Participant} that is a {@link #PARTICIPANT_IN} an
+     * {@link uk.gov.gchq.hqdm.model.Ownership}.
+     */
+    public static final HqdmIri OWNER = new HqdmIri(HQDM, "owner");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Association} that {@link #CONSISTS_OF} an
+     * {@link uk.gov.gchq.hqdm.model.Owner} and an {@link uk.gov.gchq.hqdm.model.Asset} where the
+     * {@link uk.gov.gchq.hqdm.model.Owner} owns the {@link uk.gov.gchq.hqdm.model.Asset}.
+     */
+    public static final HqdmIri OWNERSHIP = new HqdmIri(HQDM, "ownership");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.State} that is a {@link #PARTICIPANT_IN} an
+     * {@link uk.gov.gchq.hqdm.model.Activity} or {@link uk.gov.gchq.hqdm.model.Association}.
+     */
     public static final HqdmIri PARTICIPANT = new HqdmIri(HQDM, "participant");
+
+    /**
+     * A SELECT where a {@link uk.gov.gchq.hqdm.model.Participant} may be a {@link #PARTICIPANT_IN}
+     * an {@link uk.gov.gchq.hqdm.model.Activity} or an {@link uk.gov.gchq.hqdm.model.Association}.
+     */
+    public static final HqdmIri PARTICIPANT_IN_ACTIVITY_OR_ASSOCIATION =
+            new HqdmIri(HQDM, "participant_in_activity_or_association");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} that is also a
+     * {@link uk.gov.gchq.hqdm.model.System} that is a {@link uk.gov.gchq.hqdm.model.Person} or an
+     * {@link uk.gov.gchq.hqdm.model.Organization}.
+     */
+    public static final HqdmIri PARTY = new HqdmIri(HQDM, "party");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSign} where all the
+     * {@link uk.gov.gchq.hqdm.model.Sign}s are of the same {@link uk.gov.gchq.hqdm.model.Pattern}.
+     */
+    public static final HqdmIri PATTERN = new HqdmIri(HQDM, "pattern");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.State} that is a {@link #TEMPORAL_PART_OF} some
+     * {@link uk.gov.gchq.hqdm.model.PossibleWorld}.
+     */
+    public static final HqdmIri PERIOD_OF_TIME = new HqdmIri(HQDM, "period_of_time");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.BiologicalSystem} that is also, a
+     * {@link uk.gov.gchq.hqdm.model.StateOfPerson}, and a {@link uk.gov.gchq.hqdm.model.Party} that
+     * is a human being.
+     */
+    public static final HqdmIri PERSON = new HqdmIri(HQDM, "person");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPosition}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfPerson}, and an
+     * {@link uk.gov.gchq.hqdm.model.InstalledObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.Person} while they are in a
+     * {@link uk.gov.gchq.hqdm.model.Position} and also the {@link uk.gov.gchq.hqdm.model.Position}
+     * while it is filled by the {@link uk.gov.gchq.hqdm.model.Person}.
+     */
+    public static final HqdmIri PERSON_IN_POSITION = new HqdmIri(HQDM, "person_in_position");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Individual} that consists of a distribution of matter and/or
+     * energy.
+     */
+    public static final HqdmIri PHYSICAL_OBJECT = new HqdmIri(HQDM, "physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} that is some characteristic that is the same
+     * for each {@link uk.gov.gchq.hqdm.model.State} that possesses it (is a {@link #MEMBER_OF} it).
+     */
+    public static final HqdmIri PHYSICAL_PROPERTY = new HqdmIri(HQDM, "physical_property");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfState} where each member of the set is a member of a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalProperty} within the range.
+     */
+    public static final HqdmIri PHYSICAL_PROPERTY_RANGE =
+            new HqdmIri(HQDM, "physical_property_range");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.PhysicalQuantity} is a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalProperty} that is a measurable quantity of a
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalProperty}.
+     */
+    public static final HqdmIri PHYSICAL_QUANTITY = new HqdmIri(HQDM, "physical_quantity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.PhysicalPropertyRange} that ranges over
+     * {@link uk.gov.gchq.hqdm.model.PhysicalQuantity} values.
+     */
+    public static final HqdmIri PHYSICAL_QUANTITY_RANGE =
+            new HqdmIri(HQDM, "physical_quantity_range");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.PossibleWorld} that some {@link uk.gov.gchq.hqdm.model.Party}
+     * would like to bring about.
+     */
+    public static final HqdmIri PLAN = new HqdmIri(HQDM, "plan");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Event} that is all of space at an instant from some
+     * viewpoint.
+     */
+    public static final HqdmIri POINT_IN_TIME = new HqdmIri(HQDM, "point_in_time");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.OrganizationComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfPosition} that may be held by a
+     * {@link uk.gov.gchq.hqdm.model.Person}.
+     */
+    public static final HqdmIri POSITION = new HqdmIri(HQDM, "position");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Individual} that is a complete spatio-temporal history of
+     * some possible world.
+     */
+    public static final HqdmIri POSSIBLE_WORLD = new HqdmIri(HQDM, "possible_world");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfAmountOfMoney} that is the
+     * {@link #CONSIDERATION_BY_CLASS} in an {@link uk.gov.gchq.hqdm.model.Offering}.
+     */
+    public static final HqdmIri PRICE = new HqdmIri(HQDM, "price");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSalesProductInstance} that is a set of
+     * {@link uk.gov.gchq.hqdm.model.SalesProductInstance} sold under a brand name.
+     */
+    public static final HqdmIri PRODUCT_BRAND = new HqdmIri(HQDM, "product_brand");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Offering} that is for a
+     * {@link uk.gov.gchq.hqdm.model.SalesProduct}.
+     */
+    public static final HqdmIri PRODUCT_OFFERING = new HqdmIri(HQDM, "product_offering");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} where two or more parties
+     * determine a course of action.
+     */
+    public static final HqdmIri REACHING_AGREEMENT = new HqdmIri(HQDM, "reaching_agreement");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfLanguageCommunity} that recognizes what a
+     * {@link uk.gov.gchq.hqdm.model.Pattern} is intended to represent.
+     */
+    public static final HqdmIri RECOGNIZING_LANGUAGE_COMMUNITY =
+            new HqdmIri(HQDM, "recognizing_language_community");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AbstractObject} that is what one
+     * {@link uk.gov.gchq.hqdm.model.Thing} has to do with one or more others.
+     */
+    public static final HqdmIri RELATIONSHIP = new HqdmIri(HQDM, "relationship");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfRepresentation} where the
+     * {@link uk.gov.gchq.hqdm.model.Sign} in all the members are members of the
+     * {@link uk.gov.gchq.hqdm.model.Pattern} specified.
+     */
+    public static final HqdmIri REPRESENTATION_BY_PATTERN =
+            new HqdmIri(HQDM, "representation_by_pattern");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.Association} of a {@link uk.gov.gchq.hqdm.model.Sign} and a
+     * {@link uk.gov.gchq.hqdm.model.RecognizingLanguageCommunity} that recognizes the
+     * {@link uk.gov.gchq.hqdm.model.Sign} as representing some
+     * {@link uk.gov.gchq.hqdm.model.Thing}.
+     */
+    public static final HqdmIri REPRESENTATION_BY_SIGN =
+            new HqdmIri(HQDM, "representation_by_sign");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} that is {@link #PART_OF_PLAN} at least
+     * one {@link uk.gov.gchq.hqdm.model.Plan} and is {@link #DEFINED_BY} exactly one
+     * {@link uk.gov.gchq.hqdm.model.RequirementSpecification}.
+     */
+    public static final HqdmIri REQUIREMENT = new HqdmIri(HQDM, "requirement");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} that is the
+     * {@link #INTERSECTION_OF} one or more {@link uk.gov.gchq.hqdm.model.ClassOfState}.
+     */
+    public static final HqdmIri REQUIREMENT_SPECIFICATION =
+            new HqdmIri(HQDM, "requirement_specification");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfParticipant} where each member participates in the
+     * same way in an {@link uk.gov.gchq.hqdm.model.Activity} or
+     * {@link uk.gov.gchq.hqdm.model.Association}.
+     */
+    public static final HqdmIri ROLE = new HqdmIri(HQDM, "role");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.AgreementProcess} that consists of an
+     * {@link uk.gov.gchq.hqdm.model.OfferAndAcceptanceForGoods} and an
+     * {@link uk.gov.gchq.hqdm.model.ExchangeOfGoodsAndMoney}.
+     */
+    public static final HqdmIri SALE_OF_GOODS = new HqdmIri(HQDM, "sale_of_goods");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSalesProductInstance} that is a set of
+     * {@link uk.gov.gchq.hqdm.model.SalesProductInstance} sold under the same product name.
+     */
+    public static final HqdmIri SALES_PRODUCT = new HqdmIri(HQDM, "sales_product");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.OrdinaryFunctionalObject} that is produced in order to be
+     * sold.
+     */
+    public static final HqdmIri SALES_PRODUCT_INSTANCE =
+            new HqdmIri(HQDM, "sales_product_instance");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.ClassOfSalesProductInstance} that is the customer facing
+     * specification of a version of a {@link uk.gov.gchq.hqdm.model.SalesProduct}.
+     */
+    public static final HqdmIri SALES_PRODUCT_VERSION = new HqdmIri(HQDM, "sales_product_version");
+
+    /**
+     * A scale is a function from {@link uk.gov.gchq.hqdm.model.KindOfPhysicalQuantity} to the real
+     * numbers.
+     */
+    public static final HqdmIri SCALE = new HqdmIri(HQDM, "scale");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfSign}, that is also a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject}, and a
+     * {@link uk.gov.gchq.hqdm.model.Participant} that represents some
+     * {@link uk.gov.gchq.hqdm.model.Thing} for some community in one or more
+     * {@link #REPRESENTATION_BY_SIGN}.
+     */
+    public static final HqdmIri SIGN = new HqdmIri(HQDM, "sign");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} that is also an
+     * {@link uk.gov.gchq.hqdm.model.Activity}.
+     */
+    public static final HqdmIri SOCIALLY_CONSTRUCTED_ACTIVITY =
+            new HqdmIri(HQDM, "socially_constructed_activity");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject} that is necessarily
+     * constructed by agreement or at least acquiescence of many people.
+     */
+    public static final HqdmIri SOCIALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "socially_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Thing} that exists in time and space.
+     */
+    public static final HqdmIri SPATIO_TEMPORAL_EXTENT =
+            new HqdmIri(HQDM, "spatio_temporal_extent");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Relationship} where each {@link #MEMBER__OF} the
+     * {@link #SUBCLASS} is a {@link #MEMBER__OF} the {@link #SUPERCLASS}.
+     */
+    public static final HqdmIri SPECIALIZATION = new HqdmIri(HQDM, "specialization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} that is an
+     * {@link uk.gov.gchq.hqdm.model.Individual} or a {@link #TEMPORAL_PART_OF} some
+     * {@link uk.gov.gchq.hqdm.model.Individual}.
+     */
+    public static final HqdmIri STATE = new HqdmIri(HQDM, "state");
+
+    /**
+     * A state that is an {@link uk.gov.gchq.hqdm.model.Activity} or a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.Activity}.
+     */
+    public static final HqdmIri STATE_OF_ACTIVITY = new HqdmIri(HQDM, "state_of_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.AmountOfMoney}.
+     */
+    public static final HqdmIri STATE_OF_AMOUNT_OF_MONEY =
+            new HqdmIri(HQDM, "state_of_amount_of_money");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.State} that is an {@link uk.gov.gchq.hqdm.model.Association}
+     * or a {@link #TEMPORAL_PART_OF} an {@link uk.gov.gchq.hqdm.model.Association}.
+     */
+    public static final HqdmIri STATE_OF_ASSOCIATION = new HqdmIri(HQDM, "state_of_association");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalObject}.
+     */
+    public static final HqdmIri STATE_OF_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_biological_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} and
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystem} that is
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystem} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystem}.
+     */
+    public static final HqdmIri STATE_OF_BIOLOGICAL_SYSTEM =
+            new HqdmIri(HQDM, "state_of_biological_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystemComponent} and
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystemComponent} that is a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystemComponent} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystemComponent}.
+     */
+    public static final HqdmIri STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "state_of_biological_system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfIntentionallyConstructedObject} and
+     * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.FunctionalObject} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.FunctionalObject}.
+     */
+    public static final HqdmIri STATE_OF_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_functional_object");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryFunctionalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfSystem}.
+     */
+    public static final HqdmIri STATE_OF_FUNCTIONAL_SYSTEM =
+            new HqdmIri(HQDM, "state_of_functional_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfIntentionallyConstructedObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent}.
+     */
+    public static final HqdmIri STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "state_of_functional_system_component");
+
+    /**
+     * A state that is an {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject} or a
+     * {@link #TEMPORAL_PART_OF} an {@link uk.gov.gchq.hqdm.model.IntentionallyConstructedObject}.
+     */
+    public static final HqdmIri STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "state_of_intentionally_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrganization} that is a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.LanguageCommunity}.
+     */
+    public static final HqdmIri STATE_OF_LANGUAGE_COMMUNITY =
+            new HqdmIri(HQDM, "state_of_language_community");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfBiologicalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject} that is an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryBiologicalObject} or a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryBiologicalObject}.
+     */
+    public static final HqdmIri STATE_OF_ORDINARY_BIOLOGICAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_ordinary_biological_object");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.StateOfFunctionalObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject}.
+     */
+    public static final HqdmIri STATE_OF_ORDINARY_FUNCTIONAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_ordinary_functional_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is an
+     * {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} or a {@link #TEMPORAL_PART_OF} one.
+     */
+    public static final HqdmIri STATE_OF_ORDINARY_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_ordinary_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} that is an
+     * {@link uk.gov.gchq.hqdm.model.Organization} or a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.Organization}.
+     */
+    public static final HqdmIri STATE_OF_ORGANIZATION = new HqdmIri(HQDM, "state_of_organization");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfSystemComponent} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} that is a
+     * {@link #TEMPORAL_PART_OF} an {@link uk.gov.gchq.hqdm.model.OrganizationComponent}.
+     */
+    public static final HqdmIri STATE_OF_ORGANIZATION_COMPONENT =
+            new HqdmIri(HQDM, "state_of_organization_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfSystem} that is a {@link uk.gov.gchq.hqdm.model.Party}
+     * or a {@link #TEMPORAL_PART_OF} a {@link uk.gov.gchq.hqdm.model.Party}.
+     */
+    public static final HqdmIri STATE_OF_PARTY = new HqdmIri(HQDM, "state_of_party");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystem} and
+     * {@link uk.gov.gchq.hqdm.model.StateOfParty} that is a {@link uk.gov.gchq.hqdm.model.Person}
+     * or a {@link #TEMPORAL_PART_OF} a {@link uk.gov.gchq.hqdm.model.Person}.
+     */
+    public static final HqdmIri STATE_OF_PERSON = new HqdmIri(HQDM, "state_of_person");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.State} that is a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject}.
+     */
+    public static final HqdmIri STATE_OF_PHYSICAL_OBJECT =
+            new HqdmIri(HQDM, "state_of_physical_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrganizationComponent} that is a
+     * {@link uk.gov.gchq.hqdm.model.Position} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Position}.
+     */
+    public static final HqdmIri STATE_OF_POSITION = new HqdmIri(HQDM, "state_of_position");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryFunctionalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.SalesProductInstance} or a {@link #TEMPORAL_PART_OF} one.
+     */
+    public static final HqdmIri STATE_OF_SALES_PRODUCT_INSTANCE =
+            new HqdmIri(HQDM, "state_of_sales_product_instance");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.Sign} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Sign}.
+     */
+    public static final HqdmIri STATE_OF_SIGN = new HqdmIri(HQDM, "state_of_sign");
+
+    /**
+     * Any {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} that is also a
+     * {@link uk.gov.gchq.hqdm.model.StateOfActivity}.
+     */
+    public static final HqdmIri STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY =
+            new HqdmIri(HQDM, "state_of_socially_constructed_activity");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfIntentionallyConstructedObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject}.
+     */
+    public static final HqdmIri STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT =
+            new HqdmIri(HQDM, "state_of_socially_constructed_object");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.System} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.System}.
+     */
+    public static final HqdmIri STATE_OF_SYSTEM = new HqdmIri(HQDM, "state_of_system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} that is a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} or a {@link #TEMPORAL_PART_OF} a
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent}.
+     */
+    public static final HqdmIri STATE_OF_SYSTEM_COMPONENT =
+            new HqdmIri(HQDM, "state_of_system_component");
+
+    /**
+     * An {@link uk.gov.gchq.hqdm.model.OrdinaryPhysicalObject} that is an organized or connected
+     * group of {@link uk.gov.gchq.hqdm.model.PhysicalObject}.
+     */
+    public static final HqdmIri SYSTEM = new HqdmIri(HQDM, "system");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.PhysicalObject} that is a {@link #COMPONENT_OF} a
+     * {@link uk.gov.gchq.hqdm.model.System} and that can be completely replaced without losing
+     * identity.
+     */
+    public static final HqdmIri SYSTEM_COMPONENT = new HqdmIri(HQDM, "system_component");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Composition} where the part is the entire {@link #WHOLE}
+     * spatially, but part of the {@link #WHOLE} temporally.
+     */
+    public static final HqdmIri TEMPORAL_COMPOSITION = new HqdmIri(HQDM, "temporal_composition");
+
+    /**
+     * Anything that exists, real or imagined.
+     */
+    public static final HqdmIri THING = new HqdmIri(HQDM, "thing");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} and {@link uk.gov.gchq.hqdm.model.Participant}
+     * receiving {@link uk.gov.gchq.hqdm.model.Ownership} in a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership}.
+     */
+    public static final HqdmIri TRANSFEREE = new HqdmIri(HQDM, "transferee");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} that ends one
+     * {@link uk.gov.gchq.hqdm.model.Ownership} and begins another for
+     * {@link uk.gov.gchq.hqdm.model.Asset}s that are a {@link #TEMPORAL_PART_OF} the same
+     * {@link uk.gov.gchq.hqdm.model.PhysicalObject}.
+     */
+    public static final HqdmIri TRANSFER_OF_OWNERSHIP = new HqdmIri(HQDM, "transfer_of_ownership");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} where the
+     * {@link uk.gov.gchq.hqdm.model.Asset} is a {@link uk.gov.gchq.hqdm.model.MoneyAsset}.
+     */
+    public static final HqdmIri TRANSFER_OF_OWNERSHIP_OF_MONEY =
+            new HqdmIri(HQDM, "transfer_of_ownership_of_money");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.StateOfParty} that is also a
+     * {@link uk.gov.gchq.hqdm.model.Participant} that is a {@link #TEMPORAL_PART_OF} an
+     * {@link uk.gov.gchq.hqdm.model.Owner} that is a {@link #PARTICIPANT_IN} one or more
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership}.
+     */
+    public static final HqdmIri TRANSFEROR = new HqdmIri(HQDM, "transferor");
+
+    /**
+     * A plus one {@link uk.gov.gchq.hqdm.model.Function_} for a
+     * {@link uk.gov.gchq.hqdm.model.Scale}.
+     */
+    public static final HqdmIri UNIT_OF_MEASURE = new HqdmIri(HQDM, "unit_of_measure");
+
+    // =======================================================================
+    // Associations
+    // =======================================================================
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} may be
+     * aggregated into one or more others.
+     *
+     * <p>
+     * Note: This has the same meaning as, but different representation to, the
+     * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+     * </p>
+     */
+    public static final HqdmIri AGGREGATED_INTO = new HqdmIri(HQDM, "aggregated_into");
+
+    /**
+     * A {@link #PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.Event} that is its beginning.
+     */
+    public static final HqdmIri BEGINNING = new HqdmIri(HQDM, "beginning");
+
+    /**
+     * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of one or
+     * more {@link uk.gov.gchq.hqdm.model.Event}.
+     */
+    public static final HqdmIri CAUSES = new HqdmIri(HQDM, "causes");
+
+    /**
+     * A {@link #CAUSES} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} {@link #CAUSES} exactly one
+     * {@link uk.gov.gchq.hqdm.model.BeginningOfOwnership}.
+     */
+    public static final HqdmIri CAUSES_BEGINNING = new HqdmIri(HQDM, "causes_beginning");
+
+    /**
+     * A relationship type where a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.KindOfActivity} causes a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.ClassOfEvent}.
+     */
+    public static final HqdmIri CAUSES_BY_CLASS = new HqdmIri(HQDM, "causes_by_class");
+
+    /**
+     * A {@link #CAUSES} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} {@link #CAUSES} exactly one
+     * {@link uk.gov.gchq.hqdm.model.EndingOfOwnership}.
+     */
+    public static final HqdmIri CAUSES_ENDING = new HqdmIri(HQDM, "causes_ending");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Offering} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.ClassOfIndividual} some {@link #MEMBER_OF} which is offered.
+     */
+    public static final HqdmIri CLASS_OF_OFFERED = new HqdmIri(HQDM, "class_of_offered");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.Classification} has exactly one
+     * classifier.
+     */
+    public static final HqdmIri CLASSIFIER = new HqdmIri(HQDM, "classifier");
+
+    /**
+     * A {@link #PART_OF} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.SystemComponent} is {@link #PART_OF} exactly one
+     * {@link uk.gov.gchq.hqdm.model.System}.
+     */
+    public static final HqdmIri COMPONENT_OF = new HqdmIri(HQDM, "component_of");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Offering} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.Price} at which the {@link uk.gov.gchq.hqdm.model.Offering} is
+     * made.
+     */
+    public static final HqdmIri CONSIDERATION_BY_CLASS =
+            new HqdmIri(HQDM, "consideration_by_class");
+
+    /**
+     * A {@link #CONSISTS_OF} relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may
+     * {@link #CONSISTS_OF} one or more other {@link uk.gov.gchq.hqdm.model.Activity}.
+     */
+    public static final HqdmIri CONSISTS_OF = new HqdmIri(HQDM, "consists_of");
+
+    /**
+     * A {@link #CONSISTS_OF} relationship subtype where an entity has another {@link CONSISTS_OF}
+     * relationship.
+     *
+     * AgreeContract: A {@link #CONSISTS_OF} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.AgreeContract} {@link #CONSISTS_OF} exactly one
+     * {@link uk.gov.gchq.hqdm.model.Offer}.
+     *
+     * AgreementProcess: A {@link #CONSISTS_OF} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.AgreementProcess} consists of at least one
+     * {@link uk.gov.gchq.hqdm.model.AgreementExecution}.
+     *
+     * ExchangeOfGoodsAndMoney: A {@link #CONSISTS_OF} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.ExchangeOfGoodsAndMoney} consists of exactly one
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnershipOfMoney}.
+     *
+     * RepresentationBySign: A {@link #CONSISTS_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.RepresentationBySign} consists of one or more
+     * {@link uk.gov.gchq.hqdm.model.RecognizingLanguageCommunity}.
+     */
+    public static final HqdmIri CONSISTS_OF_ = new HqdmIri(HQDM, "consists_of_");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} may consist
+     * of one or more others.
+     *
+     * <p>
+     * Note: This is the inverse of {@link #PART__OF}.
+     * </p>
+     */
+    public static final HqdmIri CONSISTS__OF = new HqdmIri(HQDM, "consists__of");
+
+    /**
+     * A relationship type where a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfActivity} or
+     * {@link uk.gov.gchq.hqdm.model.KindOfAssociation} has a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Role} as a {@link uk.gov.gchq.hqdm.model.Participant} or part.
+     *
+     * KindOfActivity: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a {@link #MEMBER_OF}
+     * a {@link uk.gov.gchq.hqdm.model.KindOfActivity} has a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Role} as a {@link uk.gov.gchq.hqdm.model.Participant}.
+     *
+     * KindOfAssociation: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a
+     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.KindOfAssociation} has a
+     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.Role} as a part.
+     *
+     * RepresentationByPattern: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a
+     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} has a
+     * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.Pattern}.
+     */
+    public static final HqdmIri CONSISTS_OF_BY_CLASS = new HqdmIri(HQDM, "consists_of_by_class");
+
+    /**
+     * An inverse {@link #PART__OF_BY_CLASS} relationship type where a {@link #MEMBER_OF} one
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} {@link #CONSISTS_OF} another
+     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent}.
+     */
+    public static final HqdmIri CONSISTS__OF_BY_CLASS = new HqdmIri(HQDM, "consists__of_by_class");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.RecognizingLanguageCommunity} is a
+     * {@link #PARTICIPANT_IN} each {@link #MEMBER_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
+     */
+    public static final HqdmIri CONSISTS_OF_IN_MEMBERS =
+            new HqdmIri(HQDM, "consists_of_in_members");
+
+    /**
+     * A {@link #CONSISTS_OF} relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} or
+     * {@link uk.gov.gchq.hqdm.model.Association} {@link #CONSISTS_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Participant}.
+     *
+     * Activity: A {@link #CONSISTS_OF} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.Activity} {@link #CONSISTS_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.Participant}s.
+     *
+     * Association: A {@link #CONSISTS_OF} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.Association} consists of two or more
+     * {@link uk.gov.gchq.hqdm.model.Participant}s.
+     *
+     * Note: The cardinality constraint shows a minimum cardinality of one because this relationship
+     * will be retyped for particular participants in an {@link uk.gov.gchq.hqdm.model.Association}.
+     */
+    public static final HqdmIri CONSISTS_OF_PARTICIPANT =
+            new HqdmIri(HQDM, "consists_of_participant");
+
+    /**
+     * A {@link #CONSISTS_OF_PARTICIPANT} relationship subtype where an entity has another
+     * {@link #CONSISTS_OF_PARTICIPANT} relationship.
+     *
+     * Employment: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.Employment} consists of exactly one
+     * {@link uk.gov.gchq.hqdm.model.Employee}.
+     *
+     * Ownership: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.Ownership} {@link #CONSISTS_OF_PARTICIPANT} exactly one
+     * {@link uk.gov.gchq.hqdm.model.Asset}.
+     *
+     * TransferOfOwnership: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} {@link #CONSISTS_OF_PARTICIPANT} exactly
+     * one {@link uk.gov.gchq.hqdm.model.Transferee}.
+     */
+    public static final HqdmIri CONSISTS_OF_PARTICIPANT_ =
+            new HqdmIri(HQDM, "consists_of_participant_");
+
+    /**
+     * A {@link #MEMBER_OF} relationship type where a {@link uk.gov.gchq.hqdm.model.Requirement} is
+     * {@link #DEFINED_BY} exactly one {@link uk.gov.gchq.hqdm.model.RequirementSpecification}.
+     */
+    public static final HqdmIri DEFINED_BY = new HqdmIri(HQDM, "defined_by");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+     * more {@link uk.gov.gchq.hqdm.model.Thing} to be the case.
+     */
+    public static final HqdmIri DETERMINES = new HqdmIri(HQDM, "determines");
+
+    /**
+     * A relationship type where a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.KindOfActivity} determines a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.Class}.
+     */
+    public static final HqdmIri DETERMINES_BY_CLASS = new HqdmIri(HQDM, "determines_by_class");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Scale} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.KindOfPhysicalQuantity} as its {@link #DOMAIN}.
+     */
+    public static final HqdmIri DOMAIN = new HqdmIri(HQDM, "domain");
+
+    /**
+     * A {@link #PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} has exactly one event that is its ending.
+     */
+    public static final HqdmIri ENDING = new HqdmIri(HQDM, "ending");
+
+    /**
+     * A {@link #CONSISTS_OF_BY_CLASS} relationship type where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystem} has a {@link #MEMBER_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.KindOfSystemComponent} as a component.
+     */
+    public static final HqdmIri HAS_COMPONENT_BY_CLASS =
+            new HqdmIri(HQDM, "has_component_by_class");
+
+    /**
+     * A relationship type where each {@link #MEMBER_OF} the class is a {@link #MEMBER_OF} the
+     * {@link #SUPERCLASS}.
+     */
+    public static final HqdmIri HAS_SUPERCLASS = new HqdmIri(HQDM, "has_superclass");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.FunctionalObject} has one or more
+     * intended {@link uk.gov.gchq.hqdm.model.Role}(s).
+     */
+    public static final HqdmIri INTENDED_ROLE = new HqdmIri(HQDM, "intended_role");
+
+    /**
+     * A relationship type where each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.KindOfFunctionalObject} is intended to play one or more
+     * {@link uk.gov.gchq.hqdm.model.Role}(s).
+     */
+    public static final HqdmIri INTENDED_ROLE_BY_CLASS =
+            new HqdmIri(HQDM, "intended_role_by_class");
+
+    /**
+     * A {@code subtype_of} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.RequirementSpecification} is the {@link #INTERSECTION_OF} one
+     * or more {@link uk.gov.gchq.hqdm.model.ClassOfState}.
+     * 
+     * <p>
+     * Note: The {@link uk.gov.gchq.hqdm.model.RequirementSpecification} is a subtype of each of the
+     * related {@link uk.gov.gchq.hqdm.model.ClassOfState}.
+     * </p>
+     */
+    public static final HqdmIri INTERSECTION_OF = new HqdmIri(HQDM, "intersection_of");
+
+    /**
+     * A meta-relationship type where the {@link uk.gov.gchq.hqdm.model.Classification} of some
+     * thing in a {@link uk.gov.gchq.hqdm.model.Role} is involved in a
+     * {@link uk.gov.gchq.hqdm.model.Relationship}.
+     */
+    public static final HqdmIri INVOLVES = new HqdmIri(HQDM, "involves");
+
+    /**
+     * A {@code supertype_of} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.PhysicalQuantityRange} must have as {@link #LOWER_BOUND}
+     * exactly one {@link uk.gov.gchq.hqdm.model.PhysicalQuantity}.
+     */
+    public static final HqdmIri LOWER_BOUND = new HqdmIri(HQDM, "lower_bound");
+
+    /**
+     * A {@code subclass_of} relationship type where when a
+     * {@link uk.gov.gchq.hqdm.model.SalesProduct} {@link #MEETS_SPECIFICATION} of a
+     * {@link uk.gov.gchq.hqdm.model.RequirementSpecification}, each {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.SalesProduct} is a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.RequirementSpecification}.
+     */
+    public static final HqdmIri MEETS_SPECIFICATION = new HqdmIri(HQDM, "meets_specification");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.Classification} has exactly one
+     * {@link #MEMBER}.
+     */
+    public static final HqdmIri MEMBER = new HqdmIri(HQDM, "member");
+
+    /**
+     * A {@link #MEMBER_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} is a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent}.
+     */
+    public static final HqdmIri MEMBER_OF = new HqdmIri(HQDM, "member_of");
+
+    /**
+     * A {@link #MEMBER_OF} relationship subtype where an entity has another {@link MEMBER_OF}
+     * relationship.
+     *
+     * ClassOfSpatioTemporalExtent: A {@link #MEMBER_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} may be a member of one or more
+     * {@link uk.gov.gchq.hqdm.model.ClassOfClassOfSpatioTemporalExtent}.
+     *
+     * Sign: A {@link #MEMBER_OF} relationship type where a {@link uk.gov.gchq.hqdm.model.Sign} is a
+     * {@link #MEMBER_OF} one or more {@link uk.gov.gchq.hqdm.model.Pattern}.
+     *
+     * RepresentationBySign: A {@link #MEMBER_OF} relationship type where the
+     * {@link uk.gov.gchq.hqdm.model.RepresentationBySign} must be a {@link #MEMBER_OF} exactly one
+     * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
+     */
+    public static final HqdmIri MEMBER_OF_ = new HqdmIri(HQDM, "member_of_");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one or
+     * more {@link uk.gov.gchq.hqdm.model.Class}.
+     * 
+     * <p>
+     * Note: This relationship is the same as the entity type
+     * {@link uk.gov.gchq.hqdm.model.Classification}.
+     * </p>
+     */
+    public static final HqdmIri MEMBER__OF = new HqdmIri(HQDM, "member__of");
+
+    /**
+     * A {@link #MEMBER_OF} relationship type where an {@link uk.gov.gchq.hqdm.model.AmountOfMoney}
+     * may be a {@link #MEMBER_OF} exactly one {@link uk.gov.gchq.hqdm.model.Currency}.
+     */
+    public static final HqdmIri MEMBER_OF_CURRENCY = new HqdmIri(HQDM, "member_of_currency");
+
+    /**
+     * Participant: A {@link #MEMBER_OF_KIND} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.Participant} is a {@link #MEMBER_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.Role}.
+     *
+     * Individual: A {@link #MEMBER_OF} relationship type where an
+     * {@link uk.gov.gchq.hqdm.model.Individual} may be a {@link #MEMBER_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.KindOfIndividual}.
+     *
+     * DefinedRelationship: A {@link #MEMBER_OF} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.DefinedRelationship} is a {@link #MEMBER_OF} exactly one
+     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
+     */
+    public static final HqdmIri MEMBER_OF_KIND = new HqdmIri(HQDM, "member_of_kind");
+
+    /**
+     * A {@link #MEMBER_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.BiologicalSystem} has a natural role that it plays.
+     *
+     * <p>
+     * Example: My circulatory system has the natural role of circulating blood around the body.
+     * </p>
+     */
+    public static final HqdmIri NATURAL_ROLE = new HqdmIri(HQDM, "natural_role");
+
+    /**
+     * A relationship type where each {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.KindOfBiologicalSystem} naturally participates in the
+     * {@link uk.gov.gchq.hqdm.model.Role}.
+     */
+    public static final HqdmIri NATURAL_ROLE_BY_CLASS = new HqdmIri(HQDM, "natural_role_by_class");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Offering} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.Party} who makes the {@link uk.gov.gchq.hqdm.model.Offering}.
+     */
+    public static final HqdmIri OFFEROR = new HqdmIri(HQDM, "offeror");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} as the {@link #PART}.
+     */
+    public static final HqdmIri PART = new HqdmIri(HQDM, "part");
+
+    /**
+     * A {@link #PART_OF} relationship type where one {@link uk.gov.gchq.hqdm.model.Activity} may be
+     * a {@link #PART_OF} one or more others.
+     */
+    public static final HqdmIri PART_OF = new HqdmIri(HQDM, "part_of");
+
+    /**
+     * A {@link #PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a {@link #PART_OF} one or
+     * more {@link uk.gov.gchq.hqdm.model.AgreementExecution}.
+     */
+    public static final HqdmIri PART_OF_ = new HqdmIri(HQDM, "part_of_");
+
+    /**
+     * Role: A {@link #PART_OF_BY_CLASS} where a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Role} is a {@link uk.gov.gchq.hqdm.model.Participant} in a
+     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfActivity}.
+     *
+     * ClassOfSociallyConstructedActivity: A {@link #PART_OF_BY_CLASS} where a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a {@link #PART_OF} a
+     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfReachingAgreement}.
+     */
+    public static final HqdmIri PART_OF_BY_CLASS = new HqdmIri(HQDM, "part_of_by_class");
+
+    /**
+     * A {@link #CONSISTS_OF} relationship subtype where an entity has another {@link CONSISTS_OF}
+     * relationship.
+     *
+     * Role: A {@link #PART_OF_BY_CLASS} relationship type where a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.Role} is a {@link #PART_OF} a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.Class}.
+     *
+     * ClassOfSociallyConstructedActivity: A {@link #PART_OF_BY_CLASS} relationship type where a
+     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be
+     * a {@link #PART_OF} a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfAgreementExecution}.
+     */
+    public static final HqdmIri PART_OF_BY_CLASS_ = new HqdmIri(HQDM, "part_of_by_class_");
+
+    /**
+     * A {@link #PART_OF} relationship type where a {@link uk.gov.gchq.hqdm.model.Requirement} must
+     * be {@link #PART_OF} one or more {@link uk.gov.gchq.hqdm.model.Plan}s.
+     */
+    public static final HqdmIri PART_OF_PLAN = new HqdmIri(HQDM, "part_of_plan");
+
+    /**
+     * A {@link #PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} may be {@link #PART_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.PossibleWorld}.
+     * 
+     * <p>
+     * Note: The relationship is optional because a {@link uk.gov.gchq.hqdm.model.PossibleWorld} is
+     * not {@link #PART_OF} any other {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent}.
+     * </p>
+     */
+    public static final HqdmIri PART_OF_POSSIBLE_WORLD =
+            new HqdmIri(HQDM, "part_of_possible_world");
+
+    /**
+     * An {@link #AGGREGATED_INTO} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} may be part of another and the whole has
+     * emergent properties and is more than just the sum of its parts.
+     */
+    public static final HqdmIri PART__OF = new HqdmIri(HQDM, "part__of");
+
+    /**
+     * A relationship type where a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} is {@link #PART_OF} a
+     * {@link #MEMBER_OF} some {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent}.
+     */
+    public static final HqdmIri PART__OF_BY_CLASS = new HqdmIri(HQDM, "part__of_by_class");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.Participant} is a
+     * {@link #PARTICIPANT_IN} an {@link uk.gov.gchq.hqdm.model.Association} or
+     * {@link uk.gov.gchq.hqdm.model.Activity}.
+     */
+    public static final HqdmIri PARTICIPANT_IN = new HqdmIri(HQDM, "participant_in");
+
+    /**
+     * A relationship that is exactly one {@link uk.gov.gchq.hqdm.model.PeriodOfTime} for which the
+     * {@link uk.gov.gchq.hqdm.model.Offering} is valid.
+     */
+    public static final HqdmIri PERIOD_OFFERED = new HqdmIri(HQDM, "period_offered");
+
+    /**
+     * A {@code supertype_of} relationship type where the members of each
+     * {@link uk.gov.gchq.hqdm.model.PhysicalProperty} in the
+     * {@link uk.gov.gchq.hqdm.model.PhysicalPropertyRange} are members of the
+     * {@link uk.gov.gchq.hqdm.model.PhysicalPropertyRange}.
+     */
+    public static final HqdmIri RANGES_OVER = new HqdmIri(HQDM, "ranges_over");
+
+    /**
+     * A relationship type where a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.KindOfActivity} references a {@link #MEMBER_OF} the
+     * {@link uk.gov.gchq.hqdm.model.Class}.
+     */
+    public static final HqdmIri REFERENCES_BY_CLASS = new HqdmIri(HQDM, "references_by_class");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+     * more {@link uk.gov.gchq.hqdm.model.Thing}.
+     */
+    public static final HqdmIri REFERENCES = new HqdmIri(HQDM, "references");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.RepresentationBySign}
+     * {@link #REPRESENTS} one or more {@link uk.gov.gchq.hqdm.model.Thing}.
+     */
+    public static final HqdmIri REPRESENTS = new HqdmIri(HQDM, "represents");
+
+    /**
+     * A relationship type where the {@link uk.gov.gchq.hqdm.model.Thing} is represented by each
+     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
+     */
+    public static final HqdmIri REPRESENTED = new HqdmIri(HQDM, "represented");
+
+    /**
+     * A relationship type where the {@link uk.gov.gchq.hqdm.model.Classification} is of a required
+     * role player for the members of a
+     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithRestriction}.
+     */
+    public static final HqdmIri REQUIRED_ROLE_PLAYER = new HqdmIri(HQDM, "required_role_player");
+
+    /**
+     * The roles that must be filled by members of a
+     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
+     */
+    public static final HqdmIri ROLES = new HqdmIri(HQDM, "roles");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Specialization} where the
+     * {@link uk.gov.gchq.hqdm.model.SalesProductVersion} may be sold as a
+     * {@link uk.gov.gchq.hqdm.model.SalesProduct}.
+     */
+    public static final HqdmIri SOLD_AS = new HqdmIri(HQDM, "sold_as");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Specialization} where the
+     * {@link uk.gov.gchq.hqdm.model.SalesProduct} is sold under a
+     * {@link uk.gov.gchq.hqdm.model.ProductBrand}.
+     */
+    public static final HqdmIri SOLD_UNDER = new HqdmIri(HQDM, "sold_under");
+
+    /**
+     * A relationship type where each {@link uk.gov.gchq.hqdm.model.Specialization} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.Class} as {@link #SUBCLASS}.
+     */
+    public static final HqdmIri SUBCLASS = new HqdmIri(HQDM, "subclass");
+
+    /**
+     * A relationship type where a {@link uk.gov.gchq.hqdm.model.SalesProductVersion} may have
+     * exactly one {@link #SUCCESSOR}.
+     */
+    public static final HqdmIri SUCCESSOR = new HqdmIri(HQDM, "successor");
+
+    /**
+     * A relationship type where each {@link uk.gov.gchq.hqdm.model.Specialization} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.Class} as {@link #SUPERCLASS}.
+     */
+    public static final HqdmIri SUPERCLASS = new HqdmIri(HQDM, "superclass");
+
+    /**
+     * A {@link #TEMPORAL_PART_OF} relationship type where a {@link uk.gov.gchq.hqdm.model.State}
+     * may be a {@link #TEMPORAL_PART_OF} one or more {@link uk.gov.gchq.hqdm.model.Individual}.
+     * 
+     * <p>
+     * Note: The relationship is optional because an {@link uk.gov.gchq.hqdm.model.Individual} is
+     * not necessarily a {@link #TEMPORAL_PART_OF} another
+     * {@link uk.gov.gchq.hqdm.model.Individual}, yet is a {@link #MEMBER_OF}
+     * {@link uk.gov.gchq.hqdm.model.State} as well as {@link uk.gov.gchq.hqdm.model.Individual}.
+     * This applies to all subtypes of {@link #TEMPORAL_PART_OF} that are between a
+     * {@code state_of_X} and {@code X}.
+     * </p>
+     */
+    public static final HqdmIri TEMPORAL_PART_OF = new HqdmIri(HQDM, "temporal_part_of");
+
+    /**
+     * A {@link #TEMPORAL_PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.PeriodOfTime} may be a {@link #TEMPORAL_PART_OF} one or more
+     * {@link uk.gov.gchq.hqdm.model.PossibleWorld}.
+     */
+    public static final HqdmIri TEMPORAL_PART_OF_ = new HqdmIri(HQDM, "temporal_part_of_");
+
+    /**
+     * A {@link #PART_OF} relationship type where a
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} may be a temporal part of one or more
+     * other {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent}.
+     */
+    public static final HqdmIri TEMPORAL__PART_OF = new HqdmIri(HQDM, "temporal__part_of");
+
+    /**
+     * A {@link uk.gov.gchq.hqdm.model.Scale} may have at most one
+     * {@link uk.gov.gchq.hqdm.model.UnitOfMeasure}.
+     *
+     * <p>
+     * Note 1: A {@link uk.gov.gchq.hqdm.model.UnitOfMeasure} may apply to more than one
+     * {@link uk.gov.gchq.hqdm.model.Scale}.
+     * </p>
+     *
+     * <p>
+     * Note 2: A {@link uk.gov.gchq.hqdm.model.Scale} may not have a
+     * {@link uk.gov.gchq.hqdm.model.UnitOfMeasure}. To have a
+     * {@link uk.gov.gchq.hqdm.model.UnitOfMeasure} the points on the
+     * {@link uk.gov.gchq.hqdm.model.Scale} must be evenly placed so that adding one means the same
+     * {@link uk.gov.gchq.hqdm.model.Thing}. This is not true for some
+     * {@link uk.gov.gchq.hqdm.model.Scale}s such as Rockwell Hardness where the points on the
+     * {@link uk.gov.gchq.hqdm.model.Scale} are an arbitrary distance apart. A
+     * {@link uk.gov.gchq.hqdm.model.Scale} will also not have a
+     * {@link uk.gov.gchq.hqdm.model.UnitOfMeasure} when it is a dimensionless
+     * {@link uk.gov.gchq.hqdm.model.Scale}.
+     * </p>
+     */
+    public static final HqdmIri UNIT = new HqdmIri(HQDM, "unit");
+
+    /**
+     * A {@code supertype_of} relationship type where each
+     * {@link uk.gov.gchq.hqdm.model.PhysicalQuantityRange} must have as {@link #UPPER_BOUND}
+     * exactly one {@link uk.gov.gchq.hqdm.model.PhysicalQuantity}.
+     */
+    public static final HqdmIri UPPER_BOUND = new HqdmIri(HQDM, "upper_bound");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.IdentificationOfPhysicalQuantity}
+     * uses exactly one {@link uk.gov.gchq.hqdm.model.Scale}.
+     */
+    public static final HqdmIri USES = new HqdmIri(HQDM, "uses");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.IdentificationOfPhysicalQuantity}
+     * consists of exactly one REAL as its value.
+     *
+     * <p>
+     * Note 1: The members of the data type REAL provide an
+     * {@link uk.gov.gchq.hqdm.model.Identification} of a real number.
+     * </p>
+     *
+     * <p>
+     * Note 2: The relationship name has been renamed from consists of by
+     * {@link uk.gov.gchq.hqdm.model.Class} to value.
+     * </p>
+     */
+    public static final HqdmIri VALUE_ = new HqdmIri(HQDM, "value_");
+
+    /**
+     * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+     * {@link uk.gov.gchq.hqdm.model.SpatioTemporalExtent} as the whole.
+     */
+    public static final HqdmIri WHOLE = new HqdmIri(HQDM, "whole");
 }

--- a/src/main/java/uk/gov/gchq/hqdm/iri/HQDM.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/HQDM.java
@@ -1786,22 +1786,6 @@ public final class HQDM {
     /**
      * A {@link #CONSISTS_OF} relationship subtype where an entity has another {@link CONSISTS_OF}
      * relationship.
-     *
-     * AgreeContract: A {@link #CONSISTS_OF} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.AgreeContract} {@link #CONSISTS_OF} exactly one
-     * {@link uk.gov.gchq.hqdm.model.Offer}.
-     *
-     * AgreementProcess: A {@link #CONSISTS_OF} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.AgreementProcess} consists of at least one
-     * {@link uk.gov.gchq.hqdm.model.AgreementExecution}.
-     *
-     * ExchangeOfGoodsAndMoney: A {@link #CONSISTS_OF} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.ExchangeOfGoodsAndMoney} consists of exactly one
-     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnershipOfMoney}.
-     *
-     * RepresentationBySign: A {@link #CONSISTS_OF} relationship type where a
-     * {@link uk.gov.gchq.hqdm.model.RepresentationBySign} consists of one or more
-     * {@link uk.gov.gchq.hqdm.model.RecognizingLanguageCommunity}.
      */
     public static final HqdmIri CONSISTS_OF_ = new HqdmIri(HQDM, "consists_of_");
 
@@ -1820,19 +1804,6 @@ public final class HQDM {
      * {@link uk.gov.gchq.hqdm.model.KindOfActivity} or
      * {@link uk.gov.gchq.hqdm.model.KindOfAssociation} has a {@link #MEMBER_OF} a
      * {@link uk.gov.gchq.hqdm.model.Role} as a {@link uk.gov.gchq.hqdm.model.Participant} or part.
-     *
-     * KindOfActivity: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a {@link #MEMBER_OF}
-     * a {@link uk.gov.gchq.hqdm.model.KindOfActivity} has a {@link #MEMBER_OF} a
-     * {@link uk.gov.gchq.hqdm.model.Role} as a {@link uk.gov.gchq.hqdm.model.Participant}.
-     *
-     * KindOfAssociation: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a
-     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.KindOfAssociation} has a
-     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.Role} as a part.
-     *
-     * RepresentationByPattern: A {@link #CONSISTS_OF_BY_CLASS} relationship type where a
-     * {@link #MEMBER_OF} the {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} has a
-     * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link #MEMBER_OF} the
-     * {@link uk.gov.gchq.hqdm.model.Pattern}.
      */
     public static final HqdmIri CONSISTS_OF_BY_CLASS = new HqdmIri(HQDM, "consists_of_by_class");
 
@@ -1853,19 +1824,8 @@ public final class HQDM {
 
     /**
      * A {@link #CONSISTS_OF} relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} or
-     * {@link uk.gov.gchq.hqdm.model.Association} {@link #CONSISTS_OF} a
-     * {@link uk.gov.gchq.hqdm.model.Participant}.
-     *
-     * Activity: A {@link #CONSISTS_OF} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.Activity} {@link #CONSISTS_OF} one or more
-     * {@link uk.gov.gchq.hqdm.model.Participant}s.
-     *
-     * Association: A {@link #CONSISTS_OF} relationship type where each
-     * {@link uk.gov.gchq.hqdm.model.Association} consists of two or more
-     * {@link uk.gov.gchq.hqdm.model.Participant}s.
-     *
-     * Note: The cardinality constraint shows a minimum cardinality of one because this relationship
-     * will be retyped for particular participants in an {@link uk.gov.gchq.hqdm.model.Association}.
+     * {@link uk.gov.gchq.hqdm.model.Association} {@link #CONSISTS_OF} at least one (for Activity)
+     * or two (for Association) of {@link uk.gov.gchq.hqdm.model.Participant}.
      */
     public static final HqdmIri CONSISTS_OF_PARTICIPANT =
             new HqdmIri(HQDM, "consists_of_participant");
@@ -1873,18 +1833,6 @@ public final class HQDM {
     /**
      * A {@link #CONSISTS_OF_PARTICIPANT} relationship subtype where an entity has another
      * {@link #CONSISTS_OF_PARTICIPANT} relationship.
-     *
-     * Employment: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.Employment} consists of exactly one
-     * {@link uk.gov.gchq.hqdm.model.Employee}.
-     *
-     * Ownership: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.Ownership} {@link #CONSISTS_OF_PARTICIPANT} exactly one
-     * {@link uk.gov.gchq.hqdm.model.Asset}.
-     *
-     * TransferOfOwnership: A {@link #CONSISTS_OF_PARTICIPANT} relationship type where a
-     * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} {@link #CONSISTS_OF_PARTICIPANT} exactly
-     * one {@link uk.gov.gchq.hqdm.model.Transferee}.
      */
     public static final HqdmIri CONSISTS_OF_PARTICIPANT_ =
             new HqdmIri(HQDM, "consists_of_participant_");
@@ -1998,18 +1946,7 @@ public final class HQDM {
 
     /**
      * A {@link #MEMBER_OF} relationship subtype where an entity has another {@link MEMBER_OF}
-     * relationship.
-     *
-     * ClassOfSpatioTemporalExtent: A {@link #MEMBER_OF} relationship type where a
-     * {@link uk.gov.gchq.hqdm.model.ClassOfSpatioTemporalExtent} may be a member of one or more
-     * {@link uk.gov.gchq.hqdm.model.ClassOfClassOfSpatioTemporalExtent}.
-     *
-     * Sign: A {@link #MEMBER_OF} relationship type where a {@link uk.gov.gchq.hqdm.model.Sign} is a
-     * {@link #MEMBER_OF} one or more {@link uk.gov.gchq.hqdm.model.Pattern}.
-     *
-     * RepresentationBySign: A {@link #MEMBER_OF} relationship type where the
-     * {@link uk.gov.gchq.hqdm.model.RepresentationBySign} must be a {@link #MEMBER_OF} exactly one
-     * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
+     * relationship that is less constrained in its scope.
      */
     public static final HqdmIri MEMBER_OF_ = new HqdmIri(HQDM, "member_of_");
 
@@ -2031,17 +1968,8 @@ public final class HQDM {
     public static final HqdmIri MEMBER_OF_CURRENCY = new HqdmIri(HQDM, "member_of_currency");
 
     /**
-     * Participant: A {@link #MEMBER_OF_KIND} relationship type where each
-     * {@link uk.gov.gchq.hqdm.model.Participant} is a {@link #MEMBER_OF} one or more
-     * {@link uk.gov.gchq.hqdm.model.Role}.
-     *
-     * Individual: A {@link #MEMBER_OF} relationship type where an
-     * {@link uk.gov.gchq.hqdm.model.Individual} may be a {@link #MEMBER_OF} one or more
-     * {@link uk.gov.gchq.hqdm.model.KindOfIndividual}.
-     *
-     * DefinedRelationship: A {@link #MEMBER_OF} relationship type where each
-     * {@link uk.gov.gchq.hqdm.model.DefinedRelationship} is a {@link #MEMBER_OF} exactly one
-     * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
+     * A {@link #MEMBER_OF} relationship type where an {@link uk.gov.gchq.hqdm.model.Individual} may
+     * be a {@link #MEMBER_OF} one or more {@link uk.gov.gchq.hqdm.model.KindOfIndividual}.
      */
     public static final HqdmIri MEMBER_OF_KIND = new HqdmIri(HQDM, "member_of_kind");
 
@@ -2088,28 +2016,16 @@ public final class HQDM {
     public static final HqdmIri PART_OF_ = new HqdmIri(HQDM, "part_of_");
 
     /**
-     * Role: A {@link #PART_OF_BY_CLASS} where a {@link #MEMBER_OF} a
-     * {@link uk.gov.gchq.hqdm.model.Role} is a {@link uk.gov.gchq.hqdm.model.Participant} in a
-     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfActivity}.
-     *
-     * ClassOfSociallyConstructedActivity: A {@link #PART_OF_BY_CLASS} where a {@link #MEMBER_OF} a
-     * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a {@link #PART_OF} a
-     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfReachingAgreement}.
+     * A {@link #PART_OF_BY_CLASS} where a {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.Role}
+     * is a {@link uk.gov.gchq.hqdm.model.Participant} in a {@link #MEMBER_OF} a
+     * {@link uk.gov.gchq.hqdm.model.ClassOfActivity}.
      */
     public static final HqdmIri PART_OF_BY_CLASS = new HqdmIri(HQDM, "part_of_by_class");
 
     /**
-     * A {@link #CONSISTS_OF} relationship subtype where an entity has another {@link CONSISTS_OF}
-     * relationship.
-     *
-     * Role: A {@link #PART_OF_BY_CLASS} relationship type where a {@link #MEMBER_OF} a
+     * A {@link #PART_OF_BY_CLASS} relationship type where a {@link #MEMBER_OF} a
      * {@link uk.gov.gchq.hqdm.model.Role} is a {@link #PART_OF} a {@link #MEMBER_OF} the
      * {@link uk.gov.gchq.hqdm.model.Class}.
-     *
-     * ClassOfSociallyConstructedActivity: A {@link #PART_OF_BY_CLASS} relationship type where a
-     * {@link #MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be
-     * a {@link #PART_OF} a {@link #MEMBER_OF} a
-     * {@link uk.gov.gchq.hqdm.model.ClassOfAgreementExecution}.
      */
     public static final HqdmIri PART_OF_BY_CLASS_ = new HqdmIri(HQDM, "part_of_by_class_");
 

--- a/src/main/java/uk/gov/gchq/hqdm/iri/HqdmIri.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/HqdmIri.java
@@ -17,22 +17,26 @@ package uk.gov.gchq.hqdm.iri;
 import uk.gov.gchq.hqdm.exception.IriException;
 
 /**
- *
+ * An implementation of Internationalized Resource Identifiers for defining HQDM entities and
+ * relationship types.
  */
 public class HqdmIri extends IRI {
+
     /**
+     * Constructs a new IRI to define a HQDM resource.
      *
-     * @param base
-     * @param value
+     * @param base IRI base namespace.
+     * @param resource HQDM resource name.
      */
-    public HqdmIri(final IriBase base, final String value) {
-        super(base, value);
+    public HqdmIri(final IriBase base, final String resource) {
+        super(base, resource);
     }
 
     /**
+     * Constructs a new IRI from a string to define a HQDM resource.
      *
-     * @param iri
-     * @throws IriException
+     * @param iri IRI string.
+     * @throws IriException If the IRI string is malformed.
      */
     public HqdmIri(final String iri) throws IriException {
         super(iri);

--- a/src/main/java/uk/gov/gchq/hqdm/iri/IRI.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/IRI.java
@@ -19,91 +19,92 @@ import java.util.Objects;
 import uk.gov.gchq.hqdm.exception.IriException;
 
 /**
- *
+ * An implementation of Internationalized Resource Identifiers.
  */
 public class IRI {
-    /** */
+
     private IriBase base;
 
-    /** */
-    private String value;
+    private String resource;
 
-    /** */
     private String iri;
 
     /**
+     * Constructs a new IRI from a base namespace and resource name.
      *
-     * @param base
-     * @param value
+     * @param base IRI base namespace.
+     * @param resource Resource name.
      */
-    public IRI(final IriBase base, final String value) {
+    public IRI(final IriBase base, final String resource) {
         this.base = base;
-        this.value = value;
-        this.iri = base.getNamespace() + value;
+        this.resource = resource;
+        this.iri = base.getNamespace() + resource;
     }
 
     /**
+     * Constructs a new IRI from a string.
      *
-     * @param iri
-     * @throws IriException
+     * @param iri IRI string.
+     * @throws IriException If the IRI string is malformed.
      */
     public IRI(final String iri) throws IriException {
         fromString(iri);
     }
 
     /**
+     * The namespace of the IRI.
      *
-     * @return
+     * @return IRI namespace.
      */
     public IriBase getBase() {
         return base;
     }
 
     /**
+     * Set the IriBase namespace of the IRI.
      *
-     * @param base
+     * @param base IRI namespace.
      */
     public void setBase(final IriBase base) {
         this.base = base;
     }
 
     /**
+     * The name of the resource.
      *
-     * @return
+     * @return Resource name.
      */
-    public String getValue() {
-        return value;
+    public String getResource() {
+        return resource;
     }
 
     /**
+     * Set the resource name.
      *
-     * @param value
+     * @param resource Resource name.
      */
-    public void setValue(final String value) {
-        this.value = value;
+    public void setResource(final String resource) {
+        this.resource = resource;
     }
 
     /**
+     * The full IRI string of the resource.
      *
-     * @return
+     * @return IRI string.
      */
     public String getIri() {
         return iri;
     }
 
     /**
+     * Set the IRI string.
      *
-     * @param iri
-     * @throws IriException
+     * @param iri IRI string.
      */
     public void setIri(final String iri) {
         this.iri = iri;
     }
 
-    /**
-     *
-     * @param iri
-     */
     private void fromString(final String iri) throws IriException {
         int index = iri.lastIndexOf('#');
         if (index < 0) {
@@ -113,15 +114,16 @@ public class IRI {
             throw new IriException("Cannot parse IRI: " + iri);
         } else {
             final String baseString = iri.substring(0, index + 1);
-            base = new IriBase(baseString, baseString);
-            value = iri.substring(index + 1);
-            this.iri = base.getNamespace() + value;
+            this.base = new IriBase(baseString, baseString);
+            this.resource = iri.substring(index + 1);
+            this.iri = base.getNamespace() + resource;
         }
     }
 
     /**
+     * Returns the full IRI string value.
      *
-     * @return
+     * @return IRI string.
      */
     @Override
     public String toString() {
@@ -129,8 +131,10 @@ public class IRI {
     }
 
     /**
+     * Compare to another {@code Object}.
      *
-     * @param object
+     * @param object Object to compare.
+     * @return True if
      */
     @Override
     public boolean equals(final Object object) {
@@ -141,15 +145,11 @@ public class IRI {
             return false;
         }
         final IRI iri = (IRI) object;
-        return Objects.equals(base, iri.base) && Objects.equals(value, iri.value);
+        return Objects.equals(base, iri.base) && Objects.equals(resource, iri.resource);
     }
 
-    /**
-     *
-     * @return
-     */
     @Override
     public int hashCode() {
-        return Objects.hash(base, value);
+        return Objects.hash(base, resource);
     }
 }

--- a/src/main/java/uk/gov/gchq/hqdm/iri/IriBase.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/IriBase.java
@@ -17,67 +17,66 @@ package uk.gov.gchq.hqdm.iri;
 import java.util.Objects;
 
 /**
- *
+ * The base namespace of an {@link IRI}.
  */
 public class IriBase {
-    /** */
+
     private String prefix;
 
-    /** */
     private String namespace;
 
     /**
-     *
-     * @param prefix
-     * @param value
-     */
-    public IriBase(final String prefix, final String value) {
-        this.prefix = prefix;
-        this.namespace = value;
-    }
-
-    /**
-     *
+     * Constructs a new blank IriBase.
      */
     public IriBase() {}
 
     /**
+     * Constructs a new IriBase with a prefix and namespace.
      *
-     * @return
+     * @param prefix Prefix label for the vocabulary.
+     * @param namespace URL of the namespace.
+     */
+    public IriBase(final String prefix, final String namespace) {
+        this.prefix = prefix;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Return the prefix label of the namespace.
+     *
+     * @return Namespace prefix.
      */
     public String getPrefix() {
         return prefix;
     }
 
     /**
+     * Set the prefix label for the namespace.
      *
-     * @param prefix
+     * @param prefix Namespace prefix.
      */
     public void setPrefix(final String prefix) {
         this.prefix = prefix;
     }
 
     /**
+     * Return the URL of the namespace.
      *
-     * @return
+     * @return Namespace URL.
      */
     public String getNamespace() {
         return namespace;
     }
 
     /**
+     * Set the URL of the namespace.
      *
-     * @param namespace
+     * @param namespace Namespace URL.
      */
     public void setNamespace(final String namespace) {
         this.namespace = namespace;
     }
 
-    /**
-     *
-     * @param object
-     * @return
-     */
     @Override
     public boolean equals(final Object object) {
         if (this == object) {
@@ -90,10 +89,6 @@ public class IriBase {
         return Objects.equals(namespace, iri.namespace);
     }
 
-    /**
-     *
-     * @return
-     */
     @Override
     public int hashCode() {
         return Objects.hash(namespace);

--- a/src/main/java/uk/gov/gchq/hqdm/iri/RDFS.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/RDFS.java
@@ -15,22 +15,46 @@
 package uk.gov.gchq.hqdm.iri;
 
 /**
- *
+ * RDF Schema IRI definitions.
  */
 public final class RDFS {
+
     private RDFS() {}
 
-    /** */
+    /**
+     * Base namespace of the RDF Concepts Vocabulary (RDF).
+     * 
+     * <p>
+     * RDF Schema for the RDF vocabulary terms in the RDF Namespace.
+     * </p>
+     *
+     * @see <a href= "https://www.w3.org/TR/rdf-schema/">https://www.w3.org/TR/rdf-schema/</a>
+     */
     public static final IriBase RDF =
             new IriBase("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
 
-    /** */
+    /**
+     * {@code rdf:type} is an instance of {@code rdf:Property} that is used to state that a resource
+     * is an instance of a class.
+     */
     public static final IRI RDF_TYPE = new IRI(RDF, "type");
 
-    /** */
+    /**
+     * Base namespace of the RDF Schema vocabulary (RDFS).
+     *
+     * <p>
+     * RDF Schema provides a data-modelling vocabulary for RDF data. RDF Schema is an extension of
+     * the basic RDF vocabulary.
+     * </p>
+     *
+     * @see <a href= "https://www.w3.org/TR/rdf-schema/">https://www.w3.org/TR/rdf-schema/</a>
+     */
     public static final IriBase RDFS =
-            new IriBase("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
+            new IriBase("rdfs", "t");
 
-    /** */
+    /**
+     * The class {@code rdfs:Literal} is the class of literal values such as strings and integers.
+     * Property values such as textual strings are examples of RDF literals.
+     */
     public static final IRI RDFS_LITERAL = new IRI(RDFS, "Literal");
 }

--- a/src/main/java/uk/gov/gchq/hqdm/iri/package-info.java
+++ b/src/main/java/uk/gov/gchq/hqdm/iri/package-info.java
@@ -1,4 +1,19 @@
-/**
+/*
+ * Copyright 2021 Crown Copyright
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Classes for constructing and using Internationalized Resource Identifiers (IRIs) with HQDM
+ * objects.
  */
 package uk.gov.gchq.hqdm.iri;

--- a/src/main/java/uk/gov/gchq/hqdm/model/AbstractObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/AbstractObject.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A thing that does not exist in space or time.
+ * A {@link Thing} that does not exist in space or time.
  */
 public interface AbstractObject extends Thing {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/AcceptanceOfOffer.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/AcceptanceOfOffer.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SociallyConstructedActivity} that is the acceptance of an offer as part_of an
- * {@link AgreeContract}.
+ * A {@link SociallyConstructedActivity} that is the acceptance of an {@link Offer} as
+ * {@code part_of} an {@link AgreeContract}.
  */
 public interface AcceptanceOfOffer extends SociallyConstructedActivity {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/AcceptanceOfOfferForGoods.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/AcceptanceOfOfferForGoods.java
@@ -15,9 +15,9 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ReachingAgreement} that consists of one or more offers of a
- * {@link TransferOfOwnershipOfMoney} for a {@link TransferOfOwnership} of goods where one offer is
- * accepted.
+ * A {@link ReachingAgreement} that consists of one or more {@link Offer}s of a
+ * {@link TransferOfOwnershipOfMoney} for a {@link TransferOfOwnership} of goods where one
+ * {@link Offer} is accepted.
  */
 public interface AcceptanceOfOfferForGoods extends AcceptanceOfOffer {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Activity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Activity.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Individual} that consists of its participants and causes some event.
- **/
+ * An {@link Individual} that consists of its {@link Participant}s and causes some {@link Event}.
+ */
 public interface Activity extends
         Individual,
         StateOfActivity,

--- a/src/main/java/uk/gov/gchq/hqdm/model/AgreeContract.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/AgreeContract.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ReachingAgreement} that consists of an offer of some thing in exchange for some
- * consideration, and an {@link AcceptanceOfOffer}.
+ * A {@link ReachingAgreement} that consists of an {@link Offer} of some {@link Thing} in exchange
+ * for some consideration, and an {@link AcceptanceOfOffer}.
  */
 public interface AgreeContract extends ReachingAgreement {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Asset.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Asset.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfPhysicalObject} that is also a {@link Participant} that is the participant_in an
- * {@link Ownership} that is owned.
+ * A {@link StateOfPhysicalObject} that is also a {@link Participant} that is the
+ * {@code participant_in} an {@link Ownership} that is owned.
  */
 public interface Asset extends Participant {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Association.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Association.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Individual} that consists_of the participants that are associated, and where the
- * participants are part_of the same {@link PeriodOfTime}.
+ * An {@link Individual} that {@code consists_of} the {@link Participant}s that are associated, and
+ * where the {@link Participant}s are {@code part_of} the same {@link PeriodOfTime}.
  */
 public interface Association extends
         Individual,

--- a/src/main/java/uk/gov/gchq/hqdm/model/BeginningOfOwnership.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/BeginningOfOwnership.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Event} that is the beginning of an ownership association.
+ * An {@link Event} that is the {@code beginning} of an {@link Ownership}.
  */
 public interface BeginningOfOwnership extends Event {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/ClassOfClass.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/ClassOfClass.java
@@ -15,8 +15,12 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link Class} that is {@link Class} or any of its subsets. Note: More formally this means that
- * any member_of the powerset of class is a valid member_of class_of_class.
+ * A {@link Class} that is {@link Class} or any of its subsets.
+ *
+ * <p>
+ * Note: More formally this means that any {@code member_of} the powerset of class is a valid
+ * {@code member_of} {@link ClassOfClass}.
+ * </p>
  */
 public interface ClassOfClass extends ClassOfAbstractObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/ClassOfIndividual.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/ClassOfIndividual.java
@@ -15,10 +15,13 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfState} that is {@link Individual} or any of its subsets. Note: Only classes that
- * necessarily apply to an individual for the whole of its life are valid members. Others are
- * members of class_of_state and apply to the state that is the individual for the period of time
- * that the class applies for.
+ * A {@link ClassOfState} that is {@link Individual} or any of its subsets.
+ *
+ * <p>
+ * Note: Only a class that necessarily applies to an {@link Individual} for the whole of its life
+ * are valid members. Others are members of {@link ClassOfState} and apply to the {@link State} that
+ * is the {@link Individual} for the period of time that the {@link Class} applies for.
+ * </p>
  */
 public interface ClassOfIndividual extends ClassOfState {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Classification.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Classification.java
@@ -15,8 +15,11 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link Relationship} where a thing is a member of a class. Note: This entity type is replicated
- * as the member__of relationship.
+ * A {@link Relationship} where a {@link Thing} is a member of a class{@link Class}.
+ *
+ * <p>
+ * Note: This entity type is replicated as the {@code member__of} relationship.
+ * </p>
  */
 public interface Classification extends Relationship {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Composition.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Composition.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Aggregation} where the whole is an arrangement of the parts that results in emergent
- * properties.
+ * An {@link Aggregation} where the {@code whole} is an arrangement of the parts that results in
+ * emergent properties.
  */
 public interface Composition extends Aggregation {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/ContractExecution.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/ContractExecution.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link AgreementExecution} that is the provision of some thing in exchange for some
+ * An {@link AgreementExecution} that is the provision of some {@link Thing} in exchange for some
  * consideration.
  */
 public interface ContractExecution extends AgreementExecution {

--- a/src/main/java/uk/gov/gchq/hqdm/model/Definition.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Definition.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link RepresentationByPattern} that defines a class.
+ * A {@link RepresentationByPattern} that defines a {@link Class}.
  */
 public interface Definition extends RepresentationByPattern {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Description.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Description.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link RepresentationByPattern} that describes some thing.
+ * A {@link RepresentationByPattern} that describes some {@link Thing}.
  */
 public interface Description extends RepresentationByPattern {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Employee.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Employee.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfPerson} that is a participant_in an {@link Employment}.
+ * A {@link StateOfPerson} that is a {@code participant_in} an {@link Employment}.
  */
 public interface Employee extends
         StateOfPerson,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Employer.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Employer.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfParty} that is a participant_in an {@link Employment}.
+ * A {@link StateOfParty} that is a {@code participant_in} an {@link Employment}.
  */
 public interface Employer extends
         StateOfParty,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Employment.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Employment.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Association} that consists of an employer and an employee where the employer pays the
- * employee to work for them.
+ * An {@link Association} that consists of an {@link Employer} and an {@link Employee} where the
+ * {@link Employer} pays the {@link Employee} to work for them.
  */
 public interface Employment extends Association {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/EndingOfOwnership.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/EndingOfOwnership.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Event} that is the ending of an {@link Ownership}.
+ * An {@link Event} that is the {@code ending} of an {@link Ownership}.
  */
 public interface EndingOfOwnership extends Event {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/EnumeratedClass.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/EnumeratedClass.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link Class} where each member__of the class is known.
+ * A {@link Class} where each {@code member__of} the {@link Class} is known.
  */
 public interface EnumeratedClass extends Class {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/FunctionalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/FunctionalObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * An {@link IntentionallyConstructedObject} that is also a {@link PhysicalObject} that has an
- * intended_role.
+ * {@code intended_role}.
  */
 public interface FunctionalObject extends
         IntentionallyConstructedObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/FunctionalSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/FunctionalSystemComponent.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link IntentionallyConstructedObject} that is a replaceable component_of a
+ * An {@link IntentionallyConstructedObject} that is a replaceable {@code component_of} a
  * {@link FunctionalSystem}.
  */
 public interface FunctionalSystemComponent extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/Identification.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Identification.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link RepresentationByPattern} that is a surrogate for the thing represented.
+ * A {@link RepresentationByPattern} that is a surrogate for the {@link Thing} {@code represented}.
  */
 public interface Identification extends RepresentationByPattern {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/IdentificationOfPhysicalQuantity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/IdentificationOfPhysicalQuantity.java
@@ -17,7 +17,7 @@ package uk.gov.gchq.hqdm.model;
 /**
  * An {@link Identification} that identifies a {@link PhysicalQuantity}. An
  * {@link IdentificationOfPhysicalQuantity} consists of a REAL that is a representation of the
- * value_ the physical quantity maps to on the scale.
+ * {@code value_} the physical quantity maps to on the {@link Scale}.
  */
 public interface IdentificationOfPhysicalQuantity extends Identification {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Individual.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Individual.java
@@ -15,9 +15,13 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SpatioTemporalExtent} that is not a proper temporal_part_of any other {@link Individual}
- * of the same kind. Note: In standard mereology a spatio_temporal_extent is a part of itself. Parts
- * of an individual excluding itself are called proper parts.
+ * A {@link SpatioTemporalExtent} that is not a proper {@code temporal_part_of} any other
+ * {@link Individual} of the same kind.
+ *
+ * <p>
+ * Note: In standard mereology a {@link SpatioTemporalExtent} is a part of itself. Parts of an
+ * {@link Individual} excluding itself are called proper parts.
+ * </p>
  */
 public interface Individual extends State {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/InstalledObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/InstalledObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfOrdinaryPhysicalObject} that is also a {@link StateOfSystemComponent} that is a
- * temporal_part_of an {@link OrdinaryPhysicalObject} from when it is installed as a
+ * {@code temporal_part_of} an {@link OrdinaryPhysicalObject} from when it is installed as a
  * {@link SystemComponent} to when it is removed.
  */
 public interface InstalledObject extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/IntentionallyConstructedObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/IntentionallyConstructedObject.java
@@ -16,8 +16,12 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * An {@link Individual} and {@link StateOfIntentionallyConstructedObject} that is intentionally
- * constructed. Note: being intentionally constructed means that it is an act of will or agreement
- * that makes it what it is.
+ * constructed.
+ *
+ * <p>
+ * Note: being intentionally constructed means that it is an act of will or agreement that makes it
+ * what it is.
+ * </p>
  */
 public interface IntentionallyConstructedObject extends
         Individual,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalObject.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfBiologicalObject} and a {@link KindOfPhysicalObject} where each member_of a
- * {@link KindOfBiologicalObject} is of the same kind.
+ * A {@link ClassOfBiologicalObject} and a {@link KindOfPhysicalObject} where each {@code member_of}
+ * a {@link KindOfBiologicalObject} is of the same kind.
  */
 public interface KindOfBiologicalObject extends
         ClassOfBiologicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalSystem.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalSystem.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfBiologicalSystem} that is also a {@link KindOfSystem} all of whose members have a
- * natural role that they play.
+ * natural {@link Role} that they play.
  */
 public interface KindOfBiologicalSystem extends
         ClassOfBiologicalSystem,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfBiologicalSystemComponent.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfBiologicalSystemComponent} that is also a {@link KindOfSystemComponent} where all
- * the member components play the same role in some {@link BiologicalSystem}.
+ * the member components play the same {@link Role} in some {@link BiologicalSystem}.
  */
 public interface KindOfBiologicalSystemComponent extends
         ClassOfBiologicalSystemComponent,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfFunctionalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfFunctionalObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfFunctionalObject}, that is also a {@link KindOfPhysicalObject}, and a
- * {@link KindOfIntentionallyConstructedObject} where each member_of a
+ * {@link KindOfIntentionallyConstructedObject} where each {@code member_of} a
  * {@link KindOfFunctionalObject} is of the same kind.
  */
 public interface KindOfFunctionalObject extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfFunctionalSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfFunctionalSystemComponent.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfFunctionalSystemComponent} that is also a {@link KindOfSystemComponent} where
- * each member_of a {@link KindOfFunctionalSystemComponent} is of the same kind.
+ * each {@code member_of} a {@link KindOfFunctionalSystemComponent} is of the same kind.
  */
 public interface KindOfFunctionalSystemComponent extends
         ClassOfFunctionalSystemComponent,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfIntentionallyConstructedObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfIntentionallyConstructedObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfIntentionallyConstructedObject} that is also a {@link KindOfIndividual} where
- * each member_of a {@link KindOfIntentionallyConstructedObject} is of the same kind.
+ * each {@code member_of} a {@link KindOfIntentionallyConstructedObject} is of the same kind.
  */
 public interface KindOfIntentionallyConstructedObject extends
         ClassOfIntentionallyConstructedObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfOrdinaryBiologicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfOrdinaryBiologicalObject.java
@@ -16,8 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfOrdinaryBiologicalObject} a {@link KindOfOrdinaryPhysicalObject} and a
- * {@link KindOfBiologicalObject} where each member_of a {@link KindOfOrdinaryBiologicalObject} is
- * of the same kind.
+ * {@link KindOfBiologicalObject} where each {@code member_of} a
+ * {@link KindOfOrdinaryBiologicalObject} is of the same kind.
  */
 public interface KindOfOrdinaryBiologicalObject extends
         ClassOfOrdinaryBiologicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfOrdinaryFunctionalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfOrdinaryFunctionalObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfOrdinaryBiologicalObject}, that is also a {@link KindOfOrdinaryPhysicalObject},
- * and a {@link KindOfBiologicalObject} where each member_of a
+ * and a {@link KindOfBiologicalObject} where each {@code member_of} a
  * {@link KindOfOrdinaryBiologicalObject} is of the same kind.
  */
 public interface KindOfOrdinaryFunctionalObject extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfPhysicalProperty.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfPhysicalProperty.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfPhysicalProperty} where each member_of a {@link KindOfPhysicalProperty} is of the
- * same kind.
+ * A {@link ClassOfPhysicalProperty} where each {@code member_of} a {@link KindOfPhysicalProperty}
+ * is of the same kind.
  */
 public interface KindOfPhysicalProperty extends ClassOfPhysicalProperty {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfPhysicalQuantity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfPhysicalQuantity.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfPhysicalQuantity} that is also a {@link KindOfPhysicalProperty} such that each
- * member_of the same {@link KindOfPhysicalQuantity} is comparable to the others.
+ * {@code member_of} the same {@link KindOfPhysicalQuantity} is comparable to the others.
  */
 public interface KindOfPhysicalQuantity extends
         ClassOfPhysicalQuantity,

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfRelationshipWithRestriction.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfRelationshipWithRestriction.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link KindOfRelationshipWithSignature} where one or more roles have fixed players.
+ * A {@link KindOfRelationshipWithSignature} where one or more {@code roles} have fixed players.
  */
 public interface KindOfRelationshipWithRestriction extends KindOfRelationshipWithSignature {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfRelationshipWithSignature.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfRelationshipWithSignature.java
@@ -16,8 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfRelationship} that is a subset of {@link DefinedRelationship} type where the
- * classifications involved in each {@link DefinedRelationship} have as classifiers the roles
- * specified by the {@link KindOfRelationshipWithSignature}.
+ * {@link Classification}s involved in each {@link DefinedRelationship} have as {@code classifier}s
+ * the {@code roles} specified by the {@link KindOfRelationshipWithSignature}.
  */
 public interface KindOfRelationshipWithSignature extends ClassOfRelationship {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/KindOfSystem.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/KindOfSystem.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfSystem} that is also a {@link KindOfOrdinaryPhysicalObject} where each member_of
- * a {@link KindOfSystem} is of the same kind.
+ * A {@link ClassOfSystem} that is also a {@link KindOfOrdinaryPhysicalObject} where each
+ * {@code member_of} a {@link KindOfSystem} is of the same kind.
  */
 public interface KindOfSystem extends
         ClassOfSystem,

--- a/src/main/java/uk/gov/gchq/hqdm/model/LanguageCommunity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/LanguageCommunity.java
@@ -16,8 +16,11 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * An {@link Organization} that is a group of people who share a common understanding of a set of
- * signs. Note: This is not restricted to natural languages, but also controlled languages,
- * taxonomies etc.
+ * {@link Sign}s.
+ *
+ * <p>
+ * Note: This is not restricted to natural languages, but also controlled languages, taxonomies etc.
+ * </p>
  */
 public interface LanguageCommunity extends
         StateOfLanguageCommunity,

--- a/src/main/java/uk/gov/gchq/hqdm/model/MoneyAsset.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/MoneyAsset.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An asset that is a {@link StateOfAmountOfMoney}.
+ * An {@link Asset} that is a {@link StateOfAmountOfMoney}.
  */
 public interface MoneyAsset extends
         Asset,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Offer.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Offer.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SociallyConstructedActivity} that proposes an exchange of some thing for some
+ * A {@link SociallyConstructedActivity} that proposes an exchange of some {@link Thing} for some
  * consideration.
  */
 public interface Offer extends SociallyConstructedActivity {

--- a/src/main/java/uk/gov/gchq/hqdm/model/OfferAndAcceptanceForGoods.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/OfferAndAcceptanceForGoods.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ReachingAgreement} that consists_of exactly one offer of a
+ * A {@link ReachingAgreement} that {@code consists_of} exactly one {@link Offer} of a
  * {@link TransferOfOwnershipOfMoney} for exactly one {@link TransferOfOwnership} that is accepted.
  */
 public interface OfferAndAcceptanceForGoods extends AgreeContract {

--- a/src/main/java/uk/gov/gchq/hqdm/model/OfferForGoods.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/OfferForGoods.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An offer of an {@link ExchangeOfGoodsAndMoney}.
+ * An {@link Offer} of an {@link ExchangeOfGoodsAndMoney}.
  */
 public interface OfferForGoods extends Offer {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Offering.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Offering.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfOffer} that is for a {@link ClassOfIndividual}, at a price, by a party, for a
- * {@link PeriodOfTime}.
+ * A {@link ClassOfOffer} that is for a {@link ClassOfIndividual}, at a {@link Price}, by a
+ * {@link Party}, for a {@link PeriodOfTime}.
  */
 public interface Offering extends ClassOfOffer {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Organization.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Organization.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfOrganization}, that is also a party, and a {@link SociallyConstructedObject} that
- * is an organized body of people.
+ * A {@link StateOfOrganization}, that is also a {@link Party}, and a
+ * {@link SociallyConstructedObject} that is an organized body of people.
  */
 public interface Organization extends
         StateOfOrganization,

--- a/src/main/java/uk/gov/gchq/hqdm/model/OrganizationComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/OrganizationComponent.java
@@ -16,8 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfOrganizationComponent}, {@link SystemComponent}, and
- * {@link SociallyConstructedObject} that is a component_of an {@link Organization} that can be
- * completely replaced without losing its identity.
+ * {@link SociallyConstructedObject} that is a {@code component_of} an {@link Organization} that can
+ * be completely replaced without losing its identity.
  */
 public interface OrganizationComponent extends
         StateOfOrganizationComponent,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Owner.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Owner.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfParty} that is also a {@link Participant} that is a participant_in an
+ * A {@link StateOfParty} that is also a {@link Participant} that is a {@code participant_in} an
  * {@link Ownership}.
  */
 public interface Owner extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/Ownership.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Ownership.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Association} that consists_of an {@link Owner} and an {@link Asset} where the owner
- * owns the asset.
+ * An {@link Association} that {@code consists_of} an {@link Owner} and an {@link Asset} where the
+ * {@link Owner} owns the {@link Asset}.
  */
 public interface Ownership extends Association {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Participant.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Participant.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link State} that is a participant_in an {@link Activity} or {@link Association}.
+ * A {@link State} that is a {@code participant_in} an {@link Activity} or {@link Association}.
  */
 public interface Participant extends StateOfPhysicalObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/ParticipantInActivityOrAssociation.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/ParticipantInActivityOrAssociation.java
@@ -17,7 +17,7 @@ package uk.gov.gchq.hqdm.model;
 import uk.gov.gchq.hqdm.pojo.Top;
 
 /**
- * A SELECT where a {@link Participant} may be a participant_in an {@link Activity} or an
+ * A SELECT where a {@link Participant} may be a {@code participant_in} an {@link Activity} or an
  * {@link Association}.
  */
 public interface ParticipantInActivityOrAssociation extends Top {

--- a/src/main/java/uk/gov/gchq/hqdm/model/Pattern.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Pattern.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfSign} where all the signs are of the same pattern.
+ * A {@link ClassOfSign} where all the {@link Sign}s are of the same {@link Pattern}.
  */
 public interface Pattern extends ClassOfSign {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/PeriodOfTime.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/PeriodOfTime.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link State} that is a temporal_part_of some {@link PossibleWorld}.
+ * A {@link State} that is a {@code temporal_part_of} some {@link PossibleWorld}.
  */
 public interface PeriodOfTime extends State {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Person.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Person.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link BiologicalSystem} that is also, a {@link StateOfPerson}, and a party that is a human
- * being.
+ * A {@link BiologicalSystem} that is also, a {@link StateOfPerson}, and a {@link Party} that is a
+ * human being.
  */
 public interface Person extends
         BiologicalSystem,

--- a/src/main/java/uk/gov/gchq/hqdm/model/PersonInPosition.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/PersonInPosition.java
@@ -16,8 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfPosition}, that is also a {@link StateOfPerson}, and an {@link InstalledObject}
- * that is a {@link Person} while they are in a {@link Position} and also the position while it is
- * filled by the person.
+ * that is a {@link Person} while they are in a {@link Position} and also the {@link Position} while
+ * it is filled by the {@link Person}.
  */
 public interface PersonInPosition extends
         StateOfPosition,

--- a/src/main/java/uk/gov/gchq/hqdm/model/PhysicalProperty.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/PhysicalProperty.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfState} that is some characteristic that is the same for each state that possesses
- * it (is a member_of it).
+ * A {@link ClassOfState} that is some characteristic that is the same for each {@link State} that
+ * possesses it (is a {@code member_of} it).
  */
 public interface PhysicalProperty extends ClassOfState {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/PhysicalPropertyRange.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/PhysicalPropertyRange.java
@@ -16,8 +16,12 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link ClassOfState} where each member of the set is a member of a {@link PhysicalProperty}
- * within the range. Note: The physical_property_range is a supertype of each physical_property in
- * the range.
+ * within the range.
+ *
+ * <p>
+ * Note: The {@link PhysicalPropertyRange} is a supertype of each {@link PhysicalProperty} in the
+ * range.
+ * </p>
  */
 public interface PhysicalPropertyRange extends ClassOfState {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/PointInTime.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/PointInTime.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Event} that is the whole of space at an instant from some viewpoint.
+ * An {@link Event} that is all of space at an instant from some viewpoint.
  */
 public interface PointInTime extends Event {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Position.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Position.java
@@ -16,8 +16,12 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * An {@link OrganizationComponent} that is also a {@link StateOfPosition} that may be held by a
- * {@link Person}. Note: Normally a position is held by one person at a time, but this does not have
+ * {@link Person}.
+ *
+ * <p>
+ * Note: Normally a {@link Position} is held by one {@link Person} at a time, but this does not have
  * to be the case.
+ * </P>
  */
 public interface Position extends
         OrganizationComponent,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Price.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Price.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfAmountOfMoney} that is the consideration_by_class in an offering.
+ * A {@link ClassOfAmountOfMoney} that is the {@code consideration_by_class} in an {@link Offering}.
  */
 public interface Price extends ClassOfAmountOfMoney {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/RecognizingLanguageCommunity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/RecognizingLanguageCommunity.java
@@ -15,7 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfLanguageCommunity} that recognizes what a pattern is intended to represent.
+ * A {@link StateOfLanguageCommunity} that recognizes what a {@link Pattern} is intended to
+ * represent.
  */
 public interface RecognizingLanguageCommunity extends
         StateOfLanguageCommunity,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Relationship.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Relationship.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link AbstractObject} that is what one thing has to do with one or more others.
+ * An {@link AbstractObject} that is what one {@link Thing} has to do with one or more others.
  */
 public interface Relationship extends AbstractObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/RepresentationByPattern.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/RepresentationByPattern.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfRepresentation} where the sign in all the members are members of the pattern
- * specified.
+ * A {@link ClassOfRepresentation} where the {@link Sign} in all the members are members of the
+ * {@link Pattern} specified.
  */
 public interface RepresentationByPattern extends ClassOfRepresentation {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/RepresentationBySign.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/RepresentationBySign.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * An {@link Association} of a sign and a {@link RecognizingLanguageCommunity} that recognizes the
- * {@link Sign} as representing some thing.
+ * An {@link Association} of a {@link Sign} and a {@link RecognizingLanguageCommunity} that
+ * recognizes the {@link Sign} as representing some {@link Thing}.
  */
 public interface RepresentationBySign extends Association {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Requirement.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Requirement.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SpatioTemporalExtent} that is part_of_plan at least one {@link Plan} and is defined_by
- * exactly one {@link RequirementSpecification}.
+ * A {@link SpatioTemporalExtent} that is {@code part_of_plan} at least one {@link Plan} and is
+ * {@code defined_by} exactly one {@link RequirementSpecification}.
  */
 public interface Requirement extends SpatioTemporalExtent {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/RequirementSpecification.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/RequirementSpecification.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link ClassOfSpatioTemporalExtent} that is the intersection_of one or more
+ * A {@link ClassOfSpatioTemporalExtent} that is the {@code intersection_of} one or more
  * {@link ClassOfState}.
  */
 public interface RequirementSpecification extends ClassOfSpatioTemporalExtent {

--- a/src/main/java/uk/gov/gchq/hqdm/model/Sign.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Sign.java
@@ -16,8 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfSign}, that is also a {@link SociallyConstructedObject}, and a
- * {@link Participant} that represents some thing for some community in one or more
- * representations_by_sign.
+ * {@link Participant} that represents some {@link Thing} for some community in one or more
+ * {@code representation_by_sign}.
  */
 public interface Sign extends
         SociallyConstructedObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/Specialization.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Specialization.java
@@ -15,7 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link Relationship} where each member__of the subclass is a member__of the superclass.
+ * A {@link Relationship} where each {@code member__of} the {@code subclass} is a {@code member__of}
+ * the {@code superclass}.
  */
 public interface Specialization extends Relationship {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/State.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/State.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SpatioTemporalExtent} that is an {@link Individual} or a temporal_part_of some
+ * A {@link SpatioTemporalExtent} that is an {@link Individual} or a {@code temporal_part_of} some
  * {@link Individual}.
  */
 public interface State extends SpatioTemporalExtent {

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfActivity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfActivity.java
@@ -15,8 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SociallyConstructedObject} that is also a {@link StateOfPhysicalObject} that is a
- * temporal_part_of an {@link AmountOfMoney}.
+ * A state that is an {@link Activity} or a {@code temporal_part_of} an {@link Activity}.
  */
 public interface StateOfActivity extends State {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfAmountOfMoney.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfAmountOfMoney.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link SociallyConstructedObject} that is also a {@link StateOfPhysicalObject} that is a
- * temporal_part_of an {@link AmountOfMoney}.
+ * {@code temporal_part_of} an {@link AmountOfMoney}.
  */
 public interface StateOfAmountOfMoney extends
         StateOfSociallyConstructedObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfAssociation.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfAssociation.java
@@ -15,7 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link State} that is an {@link Association} or a temporal_part_of an {@link Association}.
+ * A {@link State} that is an {@link Association} or a {@code temporal_part_of} an
+ * {@link Association}.
  */
 public interface StateOfAssociation extends State {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalObject.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfPhysicalObject} that is a {@link BiologicalObject} or a temporal_part_of a
- * {@link BiologicalObject}.
+ * A {@link StateOfPhysicalObject} that is a {@link BiologicalObject} or a {@code temporal_part_of}
+ * a {@link BiologicalObject}.
  */
 public interface StateOfBiologicalObject extends StateOfPhysicalObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalSystem.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalSystem.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfOrdinaryBiologicalObject} and {@link StateOfSystem} that is
- * {@link BiologicalSystem} or a temporal_part_of a {@link BiologicalSystem}.
+ * {@link BiologicalSystem} or a {@code temporal_part_of} a {@link BiologicalSystem}.
  */
 public interface StateOfBiologicalSystem extends
         StateOfOrdinaryBiologicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfBiologicalSystemComponent.java
@@ -16,7 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfBiologicalSystemComponent} and {@link StateOfSystemComponent} that is a
- * {@link BiologicalSystemComponent} or a temporal_part_of a {@link BiologicalSystemComponent}.
+ * {@link BiologicalSystemComponent} or a {@code temporal_part_of} a
+ * {@link BiologicalSystemComponent}.
  */
 public interface StateOfBiologicalSystemComponent extends
         StateOfBiologicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfFunctionalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfFunctionalObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfIntentionallyConstructedObject} and {@link StateOfPhysicalObject} that is a
- * {@link FunctionalObject} or a temporal_part_of a {@link FunctionalObject}.
+ * {@link FunctionalObject} or a {@code temporal_part_of} a {@link FunctionalObject}.
  */
 public interface StateOfFunctionalObject extends
         StateOfIntentionallyConstructedObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfFunctionalSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfFunctionalSystemComponent.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfIntentionallyConstructedObject} that is a {@link SystemComponent} or a
- * temporal_part_of a {@link SystemComponent}.
+ * {@code temporal_part_of} a {@link SystemComponent}.
  */
 public interface StateOfFunctionalSystemComponent extends
         StateOfFunctionalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfIntentionallyConstructedObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfIntentionallyConstructedObject.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A state that is an {@link IntentionallyConstructedObject} or a temporal_part_of an
+ * A state that is an {@link IntentionallyConstructedObject} or a {@code temporal_part_of} an
  * {@link IntentionallyConstructedObject}.
  */
 public interface StateOfIntentionallyConstructedObject extends State {

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfLanguageCommunity.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfLanguageCommunity.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfOrganization} that is a temporal_part_of a {@link LanguageCommunity}.
+ * A {@link StateOfOrganization} that is a {@code temporal_part_of} a {@link LanguageCommunity}.
  */
 public interface StateOfLanguageCommunity extends StateOfOrganization {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrdinaryBiologicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrdinaryBiologicalObject.java
@@ -16,7 +16,8 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfBiologicalObject} that is also a {@link StateOfOrdinaryPhysicalObject} that is an
- * {@link OrdinaryBiologicalObject} or a temporal_part_of an {@link OrdinaryBiologicalObject}.
+ * {@link OrdinaryBiologicalObject} or a {@code temporal_part_of} an
+ * {@link OrdinaryBiologicalObject}.
  */
 public interface StateOfOrdinaryBiologicalObject extends
         StateOfBiologicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrdinaryPhysicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrdinaryPhysicalObject.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfPhysicalObject} that is an {@link OrdinaryPhysicalObject} or a temporal_part_of
- * one.
+ * A {@link StateOfPhysicalObject} that is an {@link OrdinaryPhysicalObject} or a
+ * {@code temporal_part_of} one.
  */
 public interface StateOfOrdinaryPhysicalObject extends StateOfPhysicalObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrganization.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrganization.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfParty} that is also a {@link StateOfSociallyConstructedObject} that is an
- * {@link Organization} or a temporal_part_of an {@link Organization}.
+ * {@link Organization} or a {@code temporal_part_of} an {@link Organization}.
  */
 public interface StateOfOrganization extends
         StateOfParty,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrganizationComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfOrganizationComponent.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfSystemComponent} that is also a {@link StateOfSociallyConstructedObject} that is
- * a temporal_part_of an {@link OrganizationComponent}.
+ * a {@code temporal_part_of} an {@link OrganizationComponent}.
  */
 public interface StateOfOrganizationComponent extends
         StateOfSystemComponent,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfParty.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfParty.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfSystem} that is a {@link Party} or a temporal_part_of a {@link Party}.
+ * A {@link StateOfSystem} that is a {@link Party} or a {@code temporal_part_of} a {@link Party}.
  */
 public interface StateOfParty extends StateOfSystem {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfPerson.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfPerson.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfBiologicalSystem} and {@link StateOfParty} that is a {@link Person} or a
- * temporal_part_of a {@link Person}.
+ * {@code temporal_part_of} a {@link Person}.
  */
 public interface StateOfPerson extends
         StateOfBiologicalSystem,

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfPhysicalObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfPhysicalObject.java
@@ -15,7 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link State} that is a {@link PhysicalObject} or a temporal_part_of a {@link PhysicalObject}.
+ * A {@link State} that is a {@link PhysicalObject} or a {@code temporal_part_of} a
+ * {@link PhysicalObject}.
  */
 public interface StateOfPhysicalObject extends State {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfPosition.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfPosition.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfOrganizationComponent} that is a {@link Position} or a temporal_part_of a
+ * A {@link StateOfOrganizationComponent} that is a {@link Position} or a {@code temporal_part_of} a
  * {@link Position}.
  */
 public interface StateOfPosition extends StateOfOrganizationComponent {

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfSalesProductInstance.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfSalesProductInstance.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfOrdinaryFunctionalObject} that is a {@link SalesProductInstance} or a
- * temporal_part_of one.
+ * {@code temporal_part_of} one.
  */
 public interface StateOfSalesProductInstance extends StateOfOrdinaryFunctionalObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfSign.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfSign.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfSociallyConstructedObject} that is a {@link Sign} or a temporal_part_of a
+ * A {@link StateOfSociallyConstructedObject} that is a {@link Sign} or a {@code temporal_part_of} a
  * {@link Sign}.
  */
 public interface StateOfSign extends StateOfSociallyConstructedObject {

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfSociallyConstructedObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfSociallyConstructedObject.java
@@ -16,7 +16,7 @@ package uk.gov.gchq.hqdm.model;
 
 /**
  * A {@link StateOfIntentionallyConstructedObject} that is a {@link SociallyConstructedObject} or a
- * temporal_part_of a {@link SociallyConstructedObject}.
+ * {@code temporal_part_of} a {@link SociallyConstructedObject}.
  */
 public interface StateOfSociallyConstructedObject extends StateOfIntentionallyConstructedObject {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfSystem.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfSystem.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfOrdinaryPhysicalObject} that is a {@link System} or a temporal_part_of a
+ * A {@link StateOfOrdinaryPhysicalObject} that is a {@link System} or a {@code temporal_part_of} a
  * {@link System}.
  */
 public interface StateOfSystem extends StateOfOrdinaryPhysicalObject {

--- a/src/main/java/uk/gov/gchq/hqdm/model/StateOfSystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/StateOfSystemComponent.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfPhysicalObject} that is a {@link SystemComponent} or a temporal_part_of a
+ * A {@link StateOfPhysicalObject} that is a {@link SystemComponent} or a {@code temporal_part_of} a
  * {@link SystemComponent}.
  */
 public interface StateOfSystemComponent extends StateOfPhysicalObject {

--- a/src/main/java/uk/gov/gchq/hqdm/model/SystemComponent.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/SystemComponent.java
@@ -15,9 +15,13 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link PhysicalObject} that is a component_of a {@link System} and that can be completely
- * replaced without losing identity. Note: A system_component is existence dependent on the system
- * it is a component of, unlike any ordinary_physical_object that may be installed as the component.
+ * A {@link PhysicalObject} that is a {@code component_of} a {@link System} and that can be
+ * completely replaced without losing identity.
+ *
+ * <p>
+ * Note: A {@link SystemComponent} is existence dependent on the {@link System} it is a component
+ * of, unlike any {@link OrdinaryPhysicalObject} that may be installed as the component.
+ * </p>
  */
 public interface SystemComponent extends
         PhysicalObject,

--- a/src/main/java/uk/gov/gchq/hqdm/model/TemporalComposition.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/TemporalComposition.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link Composition} where the part is the entire whole spatially, but part of the whole
- * temporally.
+ * A {@link Composition} where the part is the entire {@code whole} spatially, but part of the
+ * {@code whole} temporally.
  */
 public interface TemporalComposition extends Composition {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/TransferOfOwnership.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/TransferOfOwnership.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link SociallyConstructedActivity} that ends one ownership and begins another for assets that
- * are a temporal_part_of the same {@link PhysicalObject}.
+ * A {@link SociallyConstructedActivity} that ends one {@link Ownership} and begins another for
+ * {@link Asset}s that are a {@code temporal_part_of} the same {@link PhysicalObject}.
  */
 public interface TransferOfOwnership extends SociallyConstructedActivity {
 }

--- a/src/main/java/uk/gov/gchq/hqdm/model/Transferee.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Transferee.java
@@ -15,7 +15,7 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfParty} and {@link Participant} receiving ownership in a
+ * A {@link StateOfParty} and {@link Participant} receiving {@link Ownership} in a
  * {@link TransferOfOwnership}.
  */
 public interface Transferee extends

--- a/src/main/java/uk/gov/gchq/hqdm/model/Transferor.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/Transferor.java
@@ -15,8 +15,8 @@
 package uk.gov.gchq.hqdm.model;
 
 /**
- * A {@link StateOfParty} that is also a {@link Participant} that is a temporal_part_of an
- * {@link Owner} that is a participant_in one or more {@link TransferOfOwnership}.
+ * A {@link StateOfParty} that is also a {@link Participant} that is a {@code temporal_part_of} an
+ * {@link Owner} that is a {@code participant_in} one or more {@link TransferOfOwnership}.
  */
 public interface Transferor extends
         StateOfParty,

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AbstractObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AbstractObjectImpl.java
@@ -28,32 +28,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AbstractObjectImpl extends HqdmObject implements AbstractObject {
     /**
+     * Constructs a new AbstractObject.
      *
-     * @param iri
+     * @param iri IRI of the AbstractObject.
      */
     public AbstractObjectImpl(final IRI iri) {
         super(AbstractObjectImpl.class, iri, ABSTRACT_OBJECT);
     }
 
     /**
-     * Builder for AbstractObjectImpl.
+     * Builder for constructing instances of AbstractObject.
      */
     public static class Builder {
-        /** */
+
         private final AbstractObjectImpl abstractObjectImpl;
 
         /**
+         * Constructs a Builder for a new AbstractObject.
          *
-         * @param iri
+         * @param iri IRI of the AbstractObject.
          */
         public Builder(final IRI iri) {
             abstractObjectImpl = new AbstractObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             abstractObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -61,9 +65,10 @@ public class AbstractObjectImpl extends HqdmObject implements AbstractObject {
         }
 
         /**
+         * Returns an instance of AbstractObject created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AbstractObject.
+         * @throws HqdmException If the AbstractObject is missing any mandatory properties.
          */
         public AbstractObject build() throws HqdmException {
             if (abstractObjectImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AcceptanceOfOfferForGoodsImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AcceptanceOfOfferForGoodsImpl.java
@@ -58,32 +58,41 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         implements AcceptanceOfOfferForGoods {
     /**
+     * Constructs a new AcceptanceOfOfferForGoods.
      *
-     * @param iri
+     * @param iri IRI of the AcceptanceOfOfferForGoods.
      */
     public AcceptanceOfOfferForGoodsImpl(final IRI iri) {
         super(AcceptanceOfOfferForGoodsImpl.class, iri, ACCEPTANCE_OF_OFFER_FOR_GOODS);
     }
 
     /**
-     * Builder for AcceptanceOfOfferForGoodsImpl.
+     * Builder for constructing instances of AcceptanceOfOfferForGoods.
      */
     public static class Builder {
-        /** */
+
         private final AcceptanceOfOfferForGoodsImpl acceptanceOfOfferForGoodsImpl;
 
         /**
+         * Constructs a Builder for a new AcceptanceOfOfferForGoods.
          *
-         * @param iri
+         * @param iri IRI of the AcceptanceOfOfferForGoods.
          */
         public Builder(final IRI iri) {
             acceptanceOfOfferForGoodsImpl = new AcceptanceOfOfferForGoodsImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferForGoodsImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -91,9 +100,11 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             acceptanceOfOfferForGoodsImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +112,11 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             acceptanceOfOfferForGoodsImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +124,15 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferForGoodsImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,9 +140,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             acceptanceOfOfferForGoodsImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -131,9 +153,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             acceptanceOfOfferForGoodsImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -141,9 +166,11 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             acceptanceOfOfferForGoodsImpl.addValue(DETERMINES, thing.getIri());
@@ -151,9 +178,11 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             acceptanceOfOfferForGoodsImpl.addValue(ENDING, event.getIri());
@@ -161,9 +190,10 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             acceptanceOfOfferForGoodsImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -171,9 +201,13 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfSociallyConstructedActivity}.
          *
-         * @param classOfSociallyConstructedActivity
-         * @return
+         * @param classOfSociallyConstructedActivity The ClassOfSociallyConstructedActivity.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedActivity classOfSociallyConstructedActivity) {
@@ -183,9 +217,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             acceptanceOfOfferForGoodsImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -193,9 +230,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferForGoodsImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -203,11 +243,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
-         * A part_of relationship type where an acceptance_of_offer_for_goods is a part_of exactly
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link AcceptanceOfOfferForGoods} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly
          * one {@link OfferAndAcceptanceForGoods}.
          *
-         * @param offerAndAcceptanceForGoods
-         * @return
+         * @param offerAndAcceptanceForGoods The OfferAndAcceptanceForGoods.
+         * @return This builder.
          */
         public final Builder part_Of_M(
                 final OfferAndAcceptanceForGoods offerAndAcceptanceForGoods) {
@@ -216,9 +257,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             acceptanceOfOfferForGoodsImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -226,9 +270,17 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             acceptanceOfOfferForGoodsImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -238,8 +290,8 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         /**
          * A references relationship to exactly one {@link OfferForGoods} accepted.
          *
-         * @param offerForGoods
-         * @return
+         * @param offerForGoods The OfferForGoods.
+         * @return This builder.
          */
         public final Builder references_M(final OfferForGoods offerForGoods) {
             acceptanceOfOfferForGoodsImpl.addValue(REFERENCES, offerForGoods.getIri());
@@ -247,9 +299,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferForGoodsImpl.addValue(TEMPORAL__PART_OF,
@@ -258,9 +313,21 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             acceptanceOfOfferForGoodsImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -268,9 +335,12 @@ public class AcceptanceOfOfferForGoodsImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of AcceptanceOfOfferForGoods created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AcceptanceOfOfferForGoods.
+         * @throws HqdmException If the AcceptanceOfOfferForGoods is missing any mandatory
+         *         properties.
          */
         public AcceptanceOfOfferForGoods build() throws HqdmException {
             if (acceptanceOfOfferForGoodsImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AcceptanceOfOfferImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AcceptanceOfOfferImpl.java
@@ -57,32 +57,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOffer {
     /**
+     * Constructs a new AcceptanceOfOffer.
      *
-     * @param iri
+     * @param iri IRI of the AcceptanceOfOffer.
      */
     public AcceptanceOfOfferImpl(final IRI iri) {
         super(AcceptanceOfOfferImpl.class, iri, ACCEPTANCE_OF_OFFER);
     }
 
     /**
-     * Builder for AcceptanceOfOfferImpl.
+     * Builder for constructing instances of AcceptanceOfOffer.
      */
     public static class Builder {
-        /** */
+
         private final AcceptanceOfOfferImpl acceptanceOfOfferImpl;
 
         /**
+         * Constructs a Builder for a new AcceptanceOfOffer.
          *
-         * @param iri
+         * @param iri IRI of the AcceptanceOfOffer.
          */
         public Builder(final IRI iri) {
             acceptanceOfOfferImpl = new AcceptanceOfOfferImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -90,9 +98,11 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             acceptanceOfOfferImpl.addValue(BEGINNING, event.getIri());
@@ -100,9 +110,11 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             acceptanceOfOfferImpl.addValue(CAUSES, event.getIri());
@@ -110,9 +122,15 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -120,9 +138,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             acceptanceOfOfferImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -130,9 +151,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             acceptanceOfOfferImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -140,9 +164,11 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             acceptanceOfOfferImpl.addValue(DETERMINES, thing.getIri());
@@ -150,9 +176,11 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             acceptanceOfOfferImpl.addValue(ENDING, event.getIri());
@@ -160,9 +188,16 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * <p>
+         * Note: This relationship is the same as the entity type
+         * {@link uk.gov.gchq.hqdm.model.Classification}.
+         * </p>
+         * clazz.
+         *
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             acceptanceOfOfferImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -170,9 +205,13 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfSociallyConstructedActivity}.
          *
-         * @param classOfSociallyConstructedActivity
-         * @return
+         * @param classOfSociallyConstructedActivity The ClassOfSociallyConstructedActivity.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedActivity classOfSociallyConstructedActivity) {
@@ -181,9 +220,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             acceptanceOfOfferImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -191,9 +233,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -201,11 +246,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
-         * A part_of relationship type where an acceptance_of_offer is part_of just one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link AcceptanceOfOffer} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} just one
          * {@link AgreeContract}.
          *
-         * @param agreeContract
-         * @return
+         * @param agreeContract The AgreeContract.
+         * @return Builder
          */
         public final Builder part_Of_M(final AgreeContract agreeContract) {
             acceptanceOfOfferImpl.addValue(PART_OF, agreeContract.getIri());
@@ -213,9 +259,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             acceptanceOfOfferImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -223,9 +272,17 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             acceptanceOfOfferImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -233,11 +290,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
-         * A references relationship type where an acceptance_of_offer references exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#REFERENCES} relationship type where an
+         * {@link AcceptanceOfOffer} {@link uk.gov.gchq.hqdm.iri.HQDM#REFERENCES} exactly one
          * {@link Offer} that is accepted.
          *
-         * @param offer
-         * @return
+         * @param offer The Offer.
+         * @return Builder
          */
         public final Builder references_M(final Offer offer) {
             acceptanceOfOfferImpl.addValue(REFERENCES, offer.getIri());
@@ -245,9 +303,12 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             acceptanceOfOfferImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -255,9 +316,21 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             acceptanceOfOfferImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -265,9 +338,10 @@ public class AcceptanceOfOfferImpl extends HqdmObject implements AcceptanceOfOff
         }
 
         /**
+         * Returns an instance of AcceptanceOfOffer created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AcceptanceOfOffer.
+         * @throws HqdmException If the AcceptanceOfOffer is missing any mandatory properties.
          */
         public AcceptanceOfOffer build() throws HqdmException {
             if (acceptanceOfOfferImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ActivityImpl.java
@@ -52,32 +52,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ActivityImpl extends HqdmObject implements Activity {
     /**
+     * Constructs a new Activity.
      *
-     * @param iri
+     * @param iri IRI of the Activity.
      */
     public ActivityImpl(final IRI iri) {
         super(ActivityImpl.class, iri, ACTIVITY);
     }
 
     /**
-     * Builder for ActivityImpl.
+     * Builder for constructing instances of Activity.
      */
     public static class Builder {
-        /** */
+
         private final ActivityImpl activityImpl;
 
         /**
+         * Constructs a Builder for a new Activity.
          *
-         * @param iri
+         * @param iri IRI of the Activity.
          */
         public Builder(final IRI iri) {
             activityImpl = new ActivityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             activityImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -85,9 +93,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             activityImpl.addValue(BEGINNING, event.getIri());
@@ -95,7 +105,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A relationship type where each activity is the cause of one or more {@link Event}.
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
+         *
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             activityImpl.addValue(CAUSES, event.getIri());
@@ -103,9 +117,15 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             activityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -113,11 +133,12 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A consists_of relationship type where an activity may consists_of one or more other
-         * activity.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             activityImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -125,11 +146,12 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A consists_of relationship type where an activity consists_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
          * {@link Participant}.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             activityImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -137,11 +159,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A relationship type where an activity may determine one or more {@link Thing} to be the
-         * case.
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             activityImpl.addValue(DETERMINES, thing.getIri());
@@ -149,9 +171,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             activityImpl.addValue(ENDING, event.getIri());
@@ -159,9 +183,10 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             activityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -169,11 +194,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A member_of relationship type where an activity may be a member_of one or more
-         * {@link ClassOfActivity}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an {@link Activity}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfActivity}.
          *
-         * @param classOfActivity
-         * @return
+         * @param classOfActivity The ClassOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfActivity classOfActivity) {
             activityImpl.addValue(MEMBER_OF, classOfActivity.getIri());
@@ -181,11 +206,12 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A member_of_kind relationship type where each activity is a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             activityImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -193,9 +219,12 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             activityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -203,10 +232,11 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A part_of relationship type where one activity may be a part_of one or more others.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where one {@link Activity}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more others.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder part_Of(final Activity activity) {
             activityImpl.addValue(PART_OF, activity.getIri());
@@ -214,9 +244,17 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             activityImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -224,10 +262,10 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
-         * A relationship type where an activity may reference one or more thing.
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             activityImpl.addValue(REFERENCES, thing.getIri());
@@ -235,9 +273,12 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             activityImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -245,9 +286,21 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             activityImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -255,9 +308,10 @@ public class ActivityImpl extends HqdmObject implements Activity {
         }
 
         /**
+         * Returns an instance of Activity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Activity.
+         * @throws HqdmException If the Activity is missing any mandatory properties.
          */
         public Activity build() throws HqdmException {
             if (activityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AggregationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AggregationImpl.java
@@ -33,32 +33,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AggregationImpl extends HqdmObject implements Aggregation {
     /**
+     * Constructs a new Aggregation.
      *
-     * @param iri
+     * @param iri IRI of the Aggregation.
      */
     public AggregationImpl(final IRI iri) {
         super(AggregationImpl.class, iri, AGGREGATION);
     }
 
     /**
-     * Builder for AggregationImpl.
+     * Builder for constructing instances of Aggregation.
      */
     public static class Builder {
-        /** */
+
         private final AggregationImpl aggregationImpl;
 
         /**
+         * Constructs a Builder for a new Aggregation.
          *
-         * @param iri
+         * @param iri IRI of the Aggregation.
          */
         public Builder(final IRI iri) {
             aggregationImpl = new AggregationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             aggregationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -66,9 +70,11 @@ public class AggregationImpl extends HqdmObject implements Aggregation {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             aggregationImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -76,11 +82,11 @@ public class AggregationImpl extends HqdmObject implements Aggregation {
         }
 
         /**
-         * A relationship type where an aggregation has exactly one {@link SpatioTemporalExtent} as
-         * the part.
+         * A relationship type where an {@link Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the part.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part_M(final SpatioTemporalExtent spatioTemporalExtent) {
             aggregationImpl.addValue(PART, spatioTemporalExtent.getIri());
@@ -88,11 +94,11 @@ public class AggregationImpl extends HqdmObject implements Aggregation {
         }
 
         /**
-         * A relationship type where an aggregation has exactly one {@link SpatioTemporalExtent} as
-         * the whole.
+         * A relationship type where an {@link Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the whole.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder whole_M(final SpatioTemporalExtent spatioTemporalExtent) {
             aggregationImpl.addValue(WHOLE, spatioTemporalExtent.getIri());
@@ -100,9 +106,10 @@ public class AggregationImpl extends HqdmObject implements Aggregation {
         }
 
         /**
+         * Returns an instance of Aggregation created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Aggregation.
+         * @throws HqdmException If the Aggregation is missing any mandatory properties.
          */
         public Aggregation build() throws HqdmException {
             if (aggregationImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreeContractImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreeContractImpl.java
@@ -58,32 +58,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AgreeContractImpl extends HqdmObject implements AgreeContract {
     /**
+     * Constructs a new AgreeContract.
      *
-     * @param iri
+     * @param iri IRI of the AgreeContract.
      */
     public AgreeContractImpl(final IRI iri) {
         super(AgreeContractImpl.class, iri, AGREE_CONTRACT);
     }
 
     /**
-     * Builder for AgreeContractImpl.
+     * Builder for constructing instances of AgreeContract.
      */
     public static class Builder {
-        /** */
+
         private final AgreeContractImpl agreeContractImpl;
 
         /**
+         * Constructs a Builder for a new AgreeContract.
          *
-         * @param iri
+         * @param iri IRI of the AgreeContract.
          */
         public Builder(final IRI iri) {
             agreeContractImpl = new AgreeContractImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             agreeContractImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -91,9 +99,11 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             agreeContractImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +111,11 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             agreeContractImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +123,15 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreeContractImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,11 +139,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
-         * A consists_of relationship type where the agree_contract consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where the
+         * {@link AgreeContract} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link AcceptanceOfOffer}.
          *
-         * @param acceptanceOfOffer
-         * @return
+         * @param acceptanceOfOffer The AcceptanceOfOffer.
+         * @return Builder
          */
         public final Builder consists_Of(final AcceptanceOfOffer acceptanceOfOffer) {
             agreeContractImpl.addValue(CONSISTS_OF, acceptanceOfOffer.getIri());
@@ -133,11 +152,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
-         * A consists_of relationship type where an agree_contract consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link AgreeContract} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link Offer}.
          *
-         * @param offer
-         * @return
+         * @param offer The Offer.
+         * @return Builder
          */
         public final Builder consists_Of_(final Offer offer) {
             agreeContractImpl.addValue(CONSISTS_OF_, offer.getIri());
@@ -145,9 +165,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             agreeContractImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -155,9 +178,11 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             agreeContractImpl.addValue(DETERMINES, thing.getIri());
@@ -165,9 +190,11 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             agreeContractImpl.addValue(ENDING, event.getIri());
@@ -175,9 +202,10 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             agreeContractImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -185,11 +213,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
-         * A member_of relationship type where an agree_contract may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link AgreeContract} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfAgreeContract}.
          *
-         * @param classOfAgreeContract
-         * @return
+         * @param classOfAgreeContract The ClassOfAgreeContract.
+         * @return Builder
          */
         public final Builder member_Of(final ClassOfAgreeContract classOfAgreeContract) {
             agreeContractImpl.addValue(MEMBER_OF, classOfAgreeContract.getIri());
@@ -197,9 +226,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             agreeContractImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -207,9 +239,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreeContractImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -217,11 +252,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
-         * A part_of relationship type where an agree_contract is part_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link AgreeContract} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly one
          * {@link ContractProcess}.
          *
-         * @param contractProcess
-         * @return
+         * @param contractProcess The ContractProcess.
+         * @return Builder
          */
         public final Builder part_Of_M(final ContractProcess contractProcess) {
             agreeContractImpl.addValue(PART_OF, contractProcess.getIri());
@@ -229,9 +265,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             agreeContractImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -239,9 +278,17 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             agreeContractImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -249,9 +296,11 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             agreeContractImpl.addValue(REFERENCES, thing.getIri());
@@ -259,9 +308,12 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreeContractImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -269,9 +321,21 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             agreeContractImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -279,9 +343,10 @@ public class AgreeContractImpl extends HqdmObject implements AgreeContract {
         }
 
         /**
+         * Returns an instance of AgreeContract created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AgreeContract.
+         * @throws HqdmException If the AgreeContract is missing any mandatory properties.
          */
         public AgreeContract build() throws HqdmException {
             if (agreeContractImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreementExecutionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreementExecutionImpl.java
@@ -55,32 +55,41 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AgreementExecutionImpl extends HqdmObject implements AgreementExecution {
     /**
+     * Constructs a new AgreementExecution.
      *
-     * @param iri
+     * @param iri IRI of the AgreementExecution.
      */
     public AgreementExecutionImpl(final IRI iri) {
         super(AgreementExecutionImpl.class, iri, AGREEMENT_EXECUTION);
     }
 
     /**
-     * Builder for AgreementExecutionImpl.
+     * Builder for constructing instances of AgreementExecution.
      */
     public static class Builder {
-        /** */
+
         private final AgreementExecutionImpl agreementExecutionImpl;
 
         /**
+         * Constructs a Builder for a new AgreementExecution.
          *
-         * @param iri
+         * @param iri IRI of the AgreementExecution.
          */
         public Builder(final IRI iri) {
             agreementExecutionImpl = new AgreementExecutionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementExecutionImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -88,9 +97,11 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             agreementExecutionImpl.addValue(BEGINNING, event.getIri());
@@ -98,9 +109,11 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             agreementExecutionImpl.addValue(CAUSES, event.getIri());
@@ -108,9 +121,15 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementExecutionImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -118,9 +137,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             agreementExecutionImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -128,9 +150,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             agreementExecutionImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -138,9 +163,11 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             agreementExecutionImpl.addValue(DETERMINES, thing.getIri());
@@ -148,9 +175,11 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             agreementExecutionImpl.addValue(ENDING, event.getIri());
@@ -158,9 +187,10 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             agreementExecutionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -168,11 +198,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
-         * A member_of relationship type where an agreement_execution may be a member_of one or more
-         * {@link ClassOfAgreementExecution}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link AgreementExecution} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
+         * more {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAgreementExecution classOfAgreementExecution) {
             agreementExecutionImpl.addValue(MEMBER_OF, classOfAgreementExecution.getIri());
@@ -180,9 +211,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             agreementExecutionImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -190,9 +224,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementExecutionImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -200,9 +237,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link AgreementExecution} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly one
+         * {@link AgreementProcess}.
          *
-         * @param agreementProcess
-         * @return
+         * @param agreementProcess The AgreementProcess.
+         * @return This builder.
          */
         public final Builder part_Of_M(final AgreementProcess agreementProcess) {
             agreementExecutionImpl.addValue(PART_OF, agreementProcess.getIri());
@@ -210,9 +250,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             agreementExecutionImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -220,9 +263,17 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             agreementExecutionImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -230,9 +281,10 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             agreementExecutionImpl.addValue(REFERENCES, thing.getIri());
@@ -240,9 +292,12 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementExecutionImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -250,9 +305,21 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             agreementExecutionImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -260,9 +327,11 @@ public class AgreementExecutionImpl extends HqdmObject implements AgreementExecu
         }
 
         /**
+         * Returns an instance of AgreementExecution created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AgreementExecution.
+         * @throws HqdmException If the AgreementExecution is missing any mandatory properties.
          */
         public AgreementExecution build() throws HqdmException {
             if (agreementExecutionImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreementProcessImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AgreementProcessImpl.java
@@ -56,32 +56,41 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AgreementProcessImpl extends HqdmObject implements AgreementProcess {
     /**
+     * Constructs a new AgreementProcess.
      *
-     * @param iri
+     * @param iri IRI of the AgreementProcess.
      */
     public AgreementProcessImpl(final IRI iri) {
         super(AgreementProcessImpl.class, iri, AGREEMENT_PROCESS);
     }
 
     /**
-     * Builder for AgreementProcessImpl.
+     * Builder for constructing instances of AgreementProcess.
      */
     public static class Builder {
-        /** */
+
         private final AgreementProcessImpl agreementProcessImpl;
 
         /**
+         * Constructs a Builder for a new AgreementProcess.
          *
-         * @param iri
+         * @param iri IRI of the AgreementProcess.
          */
         public Builder(final IRI iri) {
             agreementProcessImpl = new AgreementProcessImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementProcessImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -89,9 +98,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             agreementProcessImpl.addValue(BEGINNING, event.getIri());
@@ -99,9 +110,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             agreementProcessImpl.addValue(CAUSES, event.getIri());
@@ -109,9 +122,15 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementProcessImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -119,11 +138,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
-         * A consists_of relationship type where an agreement_process consists of exactly one
-         * {@link ReachingAgreement}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link AgreementProcess} consists of exactly one {@link ReachingAgreement}.
          *
-         * @param reachingAgreement
-         * @return
+         * @param reachingAgreement The ReachingAgreement.
+         * @return Builder
          */
         public final Builder consists_Of(final ReachingAgreement reachingAgreement) {
             agreementProcessImpl.addValue(CONSISTS_OF, reachingAgreement.getIri());
@@ -131,11 +150,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
-         * A consists_of relationship type where an agreement_process consists of at least one
-         * {@link AgreementExecution}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link AgreementProcess} consists of at least one {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return Builder
          */
         public final Builder consists_Of_(final AgreementExecution agreementExecution) {
             agreementProcessImpl.addValue(CONSISTS_OF_, agreementExecution.getIri());
@@ -143,9 +162,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             agreementProcessImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -153,9 +175,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             agreementProcessImpl.addValue(DETERMINES, thing.getIri());
@@ -163,9 +187,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             agreementProcessImpl.addValue(ENDING, event.getIri());
@@ -173,9 +199,10 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             agreementProcessImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -183,11 +210,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
-         * A member_of relationship type where an agreement_process may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link AgreementProcess} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfAgreementProcess}.
          *
-         * @param classOfAgreementProcess
-         * @return
+         * @param classOfAgreementProcess The ClassOfAgreementProcess.
+         * @return Builder
          */
         public final Builder member_Of(final ClassOfAgreementProcess classOfAgreementProcess) {
             agreementProcessImpl.addValue(MEMBER_OF, classOfAgreementProcess.getIri());
@@ -195,9 +223,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             agreementProcessImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -205,9 +236,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementProcessImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -215,9 +249,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link ReachingAgreement}.
          *
-         * @param reachingAgreement
-         * @return
+         * @param reachingAgreement The ReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of(final ReachingAgreement reachingAgreement) {
             agreementProcessImpl.addValue(PART_OF, reachingAgreement.getIri());
@@ -225,9 +262,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             agreementProcessImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -235,9 +275,17 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             agreementProcessImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -245,9 +293,11 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             agreementProcessImpl.addValue(REFERENCES, thing.getIri());
@@ -255,9 +305,12 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             agreementProcessImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -265,9 +318,21 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             agreementProcessImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -275,9 +340,10 @@ public class AgreementProcessImpl extends HqdmObject implements AgreementProcess
         }
 
         /**
+         * Returns an instance of AgreementProcess created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AgreementProcess.
+         * @throws HqdmException If the AgreementProcess is missing any mandatory properties.
          */
         public AgreementProcess build() throws HqdmException {
             if (agreementProcessImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AmountOfMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AmountOfMoneyImpl.java
@@ -45,32 +45,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
     /**
+     * Constructs a new AmountOfMoney.
      *
-     * @param iri
+     * @param iri IRI of the AmountOfMoney.
      */
     public AmountOfMoneyImpl(final IRI iri) {
         super(AmountOfMoneyImpl.class, iri, AMOUNT_OF_MONEY);
     }
 
     /**
-     * Builder for AmountOfMoneyImpl.
+     * Builder for constructing instances of AmountOfMoney.
      */
     public static class Builder {
-        /** */
+
         private final AmountOfMoneyImpl amountOfMoneyImpl;
 
         /**
+         * Constructs a Builder for a new AmountOfMoney.
          *
-         * @param iri
+         * @param iri IRI of the AmountOfMoney.
          */
         public Builder(final IRI iri) {
             amountOfMoneyImpl = new AmountOfMoneyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             amountOfMoneyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -78,9 +86,11 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             amountOfMoneyImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             amountOfMoneyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -98,9 +114,11 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             amountOfMoneyImpl.addValue(ENDING, event.getIri());
@@ -108,9 +126,11 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             amountOfMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -118,11 +138,12 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
-         * A member_of relationship type where an amount_of_money may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link AmountOfMoney} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfAmountOfMoney}.
          *
-         * @param classOfAmountOfMoney
-         * @return
+         * @param classOfAmountOfMoney The ClassOfAmountOfMoney.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAmountOfMoney classOfAmountOfMoney) {
             amountOfMoneyImpl.addValue(MEMBER_OF, classOfAmountOfMoney.getIri());
@@ -130,11 +151,12 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
-         * A member_of relationship type where an amount_of_money may be a member_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link AmountOfMoney} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} exactly one
          * {@link Currency}.
          *
-         * @param currency
-         * @return
+         * @param currency The Currency.
+         * @return This builder.
          */
         public final Builder member_Of_Currency(final Currency currency) {
             amountOfMoneyImpl.addValue(MEMBER_OF_CURRENCY, currency.getIri());
@@ -142,9 +164,13 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfSociallyConstructedObject}.
          *
-         * @param kindOfSociallyConstructedObject
-         * @return
+         * @param kindOfSociallyConstructedObject The KindOfSociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfSociallyConstructedObject kindOfSociallyConstructedObject) {
@@ -153,9 +179,12 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             amountOfMoneyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +192,17 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             amountOfMoneyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +210,12 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             amountOfMoneyImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +223,12 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfAmountOfMoney} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link AmountOfMoney}.
          *
-         * @param amountOfMoney
-         * @return
+         * @param amountOfMoney The AmountOfMoney.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final AmountOfMoney amountOfMoney) {
             amountOfMoneyImpl.addValue(TEMPORAL_PART_OF, amountOfMoney.getIri());
@@ -193,9 +236,10 @@ public class AmountOfMoneyImpl extends HqdmObject implements AmountOfMoney {
         }
 
         /**
+         * Returns an instance of AmountOfMoney created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built AmountOfMoney.
+         * @throws HqdmException If the AmountOfMoney is missing any mandatory properties.
          */
         public AmountOfMoney build() throws HqdmException {
             if (amountOfMoneyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AssetImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AssetImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AssetImpl extends HqdmObject implements Asset {
     /**
+     * Constructs a new Asset.
      *
-     * @param iri
+     * @param iri IRI of the Asset.
      */
     public AssetImpl(final IRI iri) {
         super(AssetImpl.class, iri, ASSET);
     }
 
     /**
-     * Builder for AssetImpl.
+     * Builder for constructing instances of Asset.
      */
     public static class Builder {
-        /** */
+
         private final AssetImpl assetImpl;
 
         /**
+         * Constructs a Builder for a new Asset.
          *
-         * @param iri
+         * @param iri IRI of the Asset.
          */
         public Builder(final IRI iri) {
             assetImpl = new AssetImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             assetImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             assetImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             assetImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             assetImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             assetImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.Participant} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfParticipant}.
          *
-         * @param classOfParticipant
-         * @return
+         * @param classOfParticipant The ClassOfParticipant.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfParticipant classOfParticipant) {
             assetImpl.addValue(MEMBER_OF, classOfParticipant.getIri());
@@ -129,9 +152,12 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             assetImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             assetImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             assetImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,11 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
-         * A participant_in relationship type where an asset is a participant_in exactly one
-         * {@link Ownership}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where an asset is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} exactly one {@link Ownership}.
          *
-         * @param ownership
-         * @return
+         * @param ownership The Ownership.
+         * @return This builder.
          */
         public final Builder participant_In_M(final Ownership ownership) {
             assetImpl.addValue(PARTICIPANT_IN, ownership.getIri());
@@ -171,9 +208,12 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             assetImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +221,12 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link PhysicalObject}.
          *
-         * @param physicalObject
-         * @return
+         * @param physicalObject The PhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final PhysicalObject physicalObject) {
             assetImpl.addValue(TEMPORAL_PART_OF, physicalObject.getIri());
@@ -191,9 +234,10 @@ public class AssetImpl extends HqdmObject implements Asset {
         }
 
         /**
+         * Returns an instance of Asset created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Asset.
+         * @throws HqdmException If the Asset is missing any mandatory properties.
          */
         public Asset build() throws HqdmException {
             if (assetImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/AssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/AssociationImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class AssociationImpl extends HqdmObject implements Association {
     /**
+     * Constructs a new Association.
      *
-     * @param iri
+     * @param iri IRI of the Association.
      */
     public AssociationImpl(final IRI iri) {
         super(AssociationImpl.class, iri, ASSOCIATION);
     }
 
     /**
-     * Builder for AssociationImpl.
+     * Builder for constructing instances of Association.
      */
     public static class Builder {
-        /** */
+
         private final AssociationImpl associationImpl;
 
         /**
+         * Constructs a Builder for a new Association.
          *
-         * @param iri
+         * @param iri IRI of the Association.
          */
         public Builder(final IRI iri) {
             associationImpl = new AssociationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             associationImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             associationImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             associationImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,11 +115,11 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
-         * A consists_of relationship type where each association consists of two or more
-         * {@link Participant}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where each
+         * {@link Association} consists of two or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             associationImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -111,9 +127,11 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             associationImpl.addValue(ENDING, event.getIri());
@@ -121,9 +139,11 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             associationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -131,11 +151,12 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
-         * A member_of relationship type where an association may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link Association} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfAssociation}.
          *
-         * @param classOfAssociation
-         * @return
+         * @param classOfAssociation The ClassOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAssociation classOfAssociation) {
             associationImpl.addValue(MEMBER_OF, classOfAssociation.getIri());
@@ -143,11 +164,12 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
-         * A member_of_kind relationship type where each association is a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Association} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfAssociation}.
          *
-         * @param kindOfAssociation
-         * @return
+         * @param kindOfAssociation The KindOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfAssociation kindOfAssociation) {
             associationImpl.addValue(MEMBER_OF_KIND, kindOfAssociation.getIri());
@@ -155,9 +177,12 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             associationImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -165,9 +190,17 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             associationImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -175,9 +208,12 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             associationImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -185,9 +221,21 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             associationImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -195,9 +243,10 @@ public class AssociationImpl extends HqdmObject implements Association {
         }
 
         /**
+         * Returns an instance of Association created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Association.
+         * @throws HqdmException If the Association is missing any mandatory properties.
          */
         public Association build() throws HqdmException {
             if (associationImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/BeginningOfOwnershipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/BeginningOfOwnershipImpl.java
@@ -40,32 +40,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfOwnership {
     /**
+     * Constructs a BeginningOfOwnership.
      *
-     * @param iri
+     * @param iri IRI of the BeginningOfOwnership.
      */
     public BeginningOfOwnershipImpl(final IRI iri) {
         super(BeginningOfOwnershipImpl.class, iri, BEGINNING_OF_OWNERSHIP);
     }
 
     /**
-     * Builder for BeginningOfOwnershipImpl.
+     * Builder for constructing instances of BeginningOfOwnership.
      */
     public static class Builder {
-        /** */
+
         private final BeginningOfOwnershipImpl beginningOfOwnershipImpl;
 
         /**
+         * Constructs a Builder for a new BeginningOfOwnership.
          *
-         * @param iri
+         * @param iri IRI of the BeginningOfOwnership.
          */
         public Builder(final IRI iri) {
             beginningOfOwnershipImpl = new BeginningOfOwnershipImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             beginningOfOwnershipImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -73,9 +81,11 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             beginningOfOwnershipImpl.addValue(BEGINNING, event.getIri());
@@ -83,9 +93,15 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             beginningOfOwnershipImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -93,9 +109,11 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             beginningOfOwnershipImpl.addValue(ENDING, event.getIri());
@@ -103,9 +121,11 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             beginningOfOwnershipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -113,9 +133,11 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an {@link Event}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfEvent}.
          *
-         * @param classOfEvent
-         * @return
+         * @param classOfEvent The ClassOfEvent.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfEvent classOfEvent) {
             beginningOfOwnershipImpl.addValue(MEMBER_OF, classOfEvent.getIri());
@@ -123,9 +145,12 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             beginningOfOwnershipImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -133,9 +158,17 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             beginningOfOwnershipImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -143,9 +176,12 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             beginningOfOwnershipImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -153,9 +189,11 @@ public class BeginningOfOwnershipImpl extends HqdmObject implements BeginningOfO
         }
 
         /**
+         * Returns an instance of BeginningOfOwnership created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built BeginningOfOwnership.
+         * @throws HqdmException If the BeginningOfOwnership is missing any mandatory properties.
          */
         public BeginningOfOwnership build() throws HqdmException {
             if (beginningOfOwnershipImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalObjectImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject {
     /**
+     * Constructs a new BiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the BiologicalObject.
      */
     public BiologicalObjectImpl(final IRI iri) {
         super(BiologicalObjectImpl.class, iri, BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for BiologicalObjectImpl.
+     * Builder for constructing instances of BiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final BiologicalObjectImpl biologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new BiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the BiologicalObject.
          */
         public Builder(final IRI iri) {
             biologicalObjectImpl = new BiologicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             biologicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             biologicalObjectImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             biologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
-         * A member_of relationship type where a biological_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfBiologicalObject}.
          *
-         * @param classOfBiologicalObject
-         * @return
+         * @param classOfBiologicalObject The ClassOfBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfBiologicalObject classOfBiologicalObject) {
             biologicalObjectImpl.addValue(MEMBER_OF, classOfBiologicalObject.getIri());
@@ -128,11 +149,12 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
-         * A member_of relationship type where a biological_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfBiologicalObject}.
          *
-         * @param kindOfBiologicalObject
-         * @return
+         * @param kindOfBiologicalObject The KindOfBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfBiologicalObject kindOfBiologicalObject) {
             biologicalObjectImpl.addValue(MEMBER_OF_KIND, kindOfBiologicalObject.getIri());
@@ -140,9 +162,12 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,9 +175,17 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             biologicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -160,9 +193,12 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -170,9 +206,12 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link BiologicalObject}.
          *
-         * @param biologicalObject
-         * @return
+         * @param biologicalObject The BiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final BiologicalObject biologicalObject) {
             biologicalObjectImpl.addValue(TEMPORAL_PART_OF, biologicalObject.getIri());
@@ -180,9 +219,10 @@ public class BiologicalObjectImpl extends HqdmObject implements BiologicalObject
         }
 
         /**
+         * Returns an instance of BiologicalObject created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built BiologicalObject.
+         * @throws HqdmException If the BiologicalObject is missing any mandatory properties.
          */
         public BiologicalObject build() throws HqdmException {
             if (biologicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalSystemComponentImpl.java
@@ -47,32 +47,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class BiologicalSystemComponentImpl extends HqdmObject
         implements BiologicalSystemComponent {
     /**
+     * Constructs a new BiologicalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the BiologicalSystemComponent.
      */
     public BiologicalSystemComponentImpl(final IRI iri) {
         super(BiologicalSystemComponentImpl.class, iri, BIOLOGICAL_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for BiologicalSystemComponentImpl.
+     * Builder for constructing instances of BiologicalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final BiologicalSystemComponentImpl biologicalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new BiologicalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the BiologicalSystemComponent.
          */
         public Builder(final IRI iri) {
             biologicalSystemComponentImpl = new BiologicalSystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -80,9 +88,11 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             biologicalSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -90,11 +100,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A component_of relationship type where a biological_system_component is a component_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#COMPONENT_OF} relationship type where a
+         * {@link BiologicalSystemComponent} is a {@link uk.gov.gchq.hqdm.iri.HQDM#COMPONENT_OF}
          * exactly one {@link BiologicalSystem}.
          *
-         * @param biologicalSystem
-         * @return
+         * @param biologicalSystem The BiologicalSystem.
+         * @return This builder.
          */
         public final Builder component_Of_M(final BiologicalSystem biologicalSystem) {
             biologicalSystemComponentImpl.addValue(COMPONENT_OF, biologicalSystem.getIri());
@@ -102,9 +113,15 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -112,9 +129,11 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             biologicalSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -122,9 +141,11 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             biologicalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -132,11 +153,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a biological_system_component may be a member_of one
-         * or more {@link ClassOfBiologicalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalSystemComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link ClassOfBiologicalSystemComponent}.
          *
-         * @param classOfBiologicalSystemComponent
-         * @return
+         * @param classOfBiologicalSystemComponent The ClassOfBiologicalSystemComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfBiologicalSystemComponent classOfBiologicalSystemComponent) {
@@ -146,9 +168,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfBiologicalObject}.
          *
-         * @param kindOfBiologicalObject
-         * @return
+         * @param kindOfBiologicalObject The KindOfBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfBiologicalObject kindOfBiologicalObject) {
             biologicalSystemComponentImpl.addValue(MEMBER_OF_KIND, kindOfBiologicalObject.getIri());
@@ -156,9 +181,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -166,9 +194,17 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             biologicalSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -176,9 +212,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -187,9 +226,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link BiologicalObject}.
          *
-         * @param biologicalObject
-         * @return
+         * @param biologicalObject The BiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final BiologicalObject biologicalObject) {
             biologicalSystemComponentImpl.addValue(TEMPORAL_PART_OF, biologicalObject.getIri());
@@ -197,9 +239,12 @@ public class BiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of BiologicalSystemComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built BiologicalSystemComponent.
+         * @throws HqdmException If the BiologicalSystemComponent is missing any mandatory
+         *         properties.
          */
         public BiologicalSystemComponent build() throws HqdmException {
             if (biologicalSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/BiologicalSystemImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem {
     /**
+     * Constructs a new BiologicalSystem.
      *
-     * @param iri
+     * @param iri IRI of the BiologicalSystem.
      */
     public BiologicalSystemImpl(final IRI iri) {
         super(BiologicalSystemImpl.class, iri, BIOLOGICAL_SYSTEM);
     }
 
     /**
-     * Builder for BiologicalSystemImpl.
+     * Builder for constructing instances of BiologicalSystem.
      */
     public static class Builder {
-        /** */
+
         private final BiologicalSystemImpl biologicalSystemImpl;
 
         /**
+         * Constructs a Builder for a new BiologicalSystem.
          *
-         * @param iri
+         * @param iri IRI of the BiologicalSystem.
          */
         public Builder(final IRI iri) {
             biologicalSystemImpl = new BiologicalSystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             biologicalSystemImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             biologicalSystemImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             biologicalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,12 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
-         * A member_of relationship type where a biological_system may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfBiologicalSystem}.
          *
-         * @param classOfBiologicalSystem
-         * @return
+         * @param classOfBiologicalSystem The ClassOfBiologicalSystem.
+         * @return Builder
          */
         public final Builder member_Of(final ClassOfBiologicalSystem classOfBiologicalSystem) {
             biologicalSystemImpl.addValue(MEMBER_OF, classOfBiologicalSystem.getIri());
@@ -131,11 +152,12 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
-         * A member_of_kind relationship type where a biological_system may be a member_of one or
-         * more {@link KindOfBiologicalSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link BiologicalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfBiologicalSystem}.
          *
-         * @param kindOfBiologicalSystem
-         * @return
+         * @param kindOfBiologicalSystem The KindOfBiologicalSystem.
+         * @return Builder
          */
         public final Builder member_Of_Kind(final KindOfBiologicalSystem kindOfBiologicalSystem) {
             biologicalSystemImpl.addValue(MEMBER_OF_KIND, kindOfBiologicalSystem.getIri());
@@ -143,11 +165,11 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
-         * A member_of relationship type where a biological_system has a natural {@link Role} that
-         * it plays.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link BiologicalSystem} has a natural {@link Role} that it plays.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return Builder
          */
         public final Builder natural_Role_M(final Role role) {
             biologicalSystemImpl.addValue(NATURAL_ROLE, role.getIri());
@@ -155,9 +177,12 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -165,9 +190,17 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             biologicalSystemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -175,9 +208,12 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             biologicalSystemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -185,9 +221,13 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryBiologicalObject}.
          *
-         * @param ordinaryBiologicalObject
-         * @return
+         * @param ordinaryBiologicalObject The OrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final OrdinaryBiologicalObject ordinaryBiologicalObject) {
@@ -196,9 +236,10 @@ public class BiologicalSystemImpl extends HqdmObject implements BiologicalSystem
         }
 
         /**
+         * Returns an instance of BiologicalSystem created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built BiologicalSystem.
+         * @throws HqdmException If the BiologicalSystem is missing any mandatory properties.
          */
         public BiologicalSystem build() throws HqdmException {
             if (biologicalSystemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassImpl.java
@@ -30,33 +30,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassImpl extends HqdmObject implements Class {
     /**
+     * Constructs a new Class.
      *
-     * @param iri
+     * @param iri IRI of the Class.
      */
     public ClassImpl(final IRI iri) {
         super(ClassImpl.class, iri, CLASS);
     }
 
     /**
-     * Builder for ClassImpl.
+     * Builder for constructing instances of Class.
      */
     public static class Builder {
-        /** */
+
         private final ClassImpl classImpl;
 
         /**
+         * Constructs a Builder for a new Class.
          *
-         * @param iri
+         * @param iri IRI of the Class.
          */
         public Builder(final IRI iri) {
             classImpl = new ClassImpl(iri);
         }
 
         /**
-         * A relationship type where each member_of the {@link Class} is a member_of the superclass.
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +67,11 @@ public class ClassImpl extends HqdmObject implements Class {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,11 +79,11 @@ public class ClassImpl extends HqdmObject implements Class {
         }
 
         /**
-         * A member_of relationship type where a class may be a member_of one or more
-         * {@link ClassOfClass}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -86,9 +91,10 @@ public class ClassImpl extends HqdmObject implements Class {
         }
 
         /**
+         * Returns an instance of Class created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Class.
+         * @throws HqdmException If the Class is missing any mandatory properties.
          */
         public Class build() throws HqdmException {
             if (classImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAbstractObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAbstractObjectImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfAbstractObjectImpl extends HqdmObject implements ClassOfAbstractObject {
     /**
+     * Constructs a new ClassOfAbstractObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAbstractObject.
      */
     public ClassOfAbstractObjectImpl(final IRI iri) {
         super(ClassOfAbstractObjectImpl.class, iri, CLASS_OF_ABSTRACT_OBJECT);
     }
 
     /**
-     * Builder for ClassOfAbstractObjectImpl.
+     * Builder for constructing instances of ClassOfAbstractObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAbstractObjectImpl classOfAbstractObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAbstractObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAbstractObject.
          */
         public Builder(final IRI iri) {
             classOfAbstractObjectImpl = new ClassOfAbstractObjectImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAbstractObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class ClassOfAbstractObjectImpl extends HqdmObject implements ClassOfAbst
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAbstractObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class ClassOfAbstractObjectImpl extends HqdmObject implements ClassOfAbst
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAbstractObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class ClassOfAbstractObjectImpl extends HqdmObject implements ClassOfAbst
         }
 
         /**
+         * Returns an instance of ClassOfAbstractObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAbstractObject.
+         * @throws HqdmException If the ClassOfAbstractObject is missing any mandatory properties.
          */
         public ClassOfAbstractObject build() throws HqdmException {
             if (classOfAbstractObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfActivityImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
     /**
+     * Constructs a new ClassOfActivity.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfActivity.
      */
     public ClassOfActivityImpl(final IRI iri) {
         super(ClassOfActivityImpl.class, iri, CLASS_OF_ACTIVITY);
     }
 
     /**
-     * Builder for ClassOfActivityImpl.
+     * Builder for constructing instances of ClassOfActivity.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfActivityImpl classOfActivityImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfActivity.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfActivity.
          */
         public Builder(final IRI iri) {
             classOfActivityImpl = new ClassOfActivityImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfActivityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfActivityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class ClassOfActivityImpl extends HqdmObject implements ClassOfActivity {
         }
 
         /**
+         * Returns an instance of ClassOfActivity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfActivity.
+         * @throws HqdmException If the ClassOfActivity is missing any mandatory properties.
          */
         public ClassOfActivity build() throws HqdmException {
             if (classOfActivityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreeContractImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreeContractImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgreeContract {
     /**
+     * Constructs a new ClassOfAgreeContract.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAgreeContract.
      */
     public ClassOfAgreeContractImpl(final IRI iri) {
         super(ClassOfAgreeContractImpl.class, iri, CLASS_OF_AGREE_CONTRACT);
     }
 
     /**
-     * Builder for ClassOfAgreeContractImpl.
+     * Builder for constructing instances of ClassOfAgreeContract.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAgreeContractImpl classOfAgreeContractImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAgreeContract.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAgreeContract.
          */
         public Builder(final IRI iri) {
             classOfAgreeContractImpl = new ClassOfAgreeContractImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAgreeContractImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAgreeContractImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAgreeContractImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,11 +147,13 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
-         * A part_of_by_class relationship type where a member_of the class_of_agree_contract may be
-         * a part_of a member_of one or more {@link ClassOfContractProcess}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link ClassOfAgreeContract} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link ClassOfContractProcess}.
          *
-         * @param classOfContractProcess
-         * @return
+         * @param classOfContractProcess The ClassOfContractProcess.
+         * @return Builder
          */
         public final Builder part_Of_By_Class(
                 final ClassOfContractProcess classOfContractProcess) {
@@ -142,9 +162,14 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -154,9 +179,11 @@ public class ClassOfAgreeContractImpl extends HqdmObject implements ClassOfAgree
         }
 
         /**
+         * Returns an instance of ClassOfAgreeContract created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAgreeContract.
+         * @throws HqdmException If the ClassOfAgreeContract is missing any mandatory properties.
          */
         public ClassOfAgreeContract build() throws HqdmException {
             if (classOfAgreeContractImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreementExecutionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreementExecutionImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfAgreementExecutionImpl extends HqdmObject
         implements ClassOfAgreementExecution {
     /**
+     * Constructs a new ClassOfAgreementExecution.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAgreementExecution.
      */
     public ClassOfAgreementExecutionImpl(final IRI iri) {
         super(ClassOfAgreementExecutionImpl.class, iri, CLASS_OF_AGREEMENT_EXECUTION);
     }
 
     /**
-     * Builder for ClassOfAgreementExecutionImpl.
+     * Builder for constructing instances of ClassOfAgreementExecution.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAgreementExecutionImpl classOfAgreementExecutionImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAgreementExecution.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAgreementExecution.
          */
         public Builder(final IRI iri) {
             classOfAgreementExecutionImpl = new ClassOfAgreementExecutionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAgreementExecutionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAgreementExecutionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAgreementExecutionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,11 +147,13 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
-         * A part_of_by_class relationship type where a member_of the class_of_agreement_execution
-         * may be a part_of a member_of the {@link ClassOfAgreementProcess}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link ClassOfAgreementExecution} may be
+         * a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link ClassOfAgreementProcess}.
          *
-         * @param classOfAgreementProcess
-         * @return
+         * @param classOfAgreementProcess The ClassOfAgreementProcess.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfAgreementProcess classOfAgreementProcess) {
@@ -143,9 +163,14 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -155,9 +180,12 @@ public class ClassOfAgreementExecutionImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfAgreementExecution created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAgreementExecution.
+         * @throws HqdmException If the ClassOfAgreementExecution is missing any mandatory
+         *         properties.
          */
         public ClassOfAgreementExecution build() throws HqdmException {
             if (classOfAgreementExecutionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreementProcessImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAgreementProcessImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAgreementProcess {
     /**
+     * Constructs a new ClassOfAgreementProcess.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAgreementProcess.
      */
     public ClassOfAgreementProcessImpl(final IRI iri) {
         super(ClassOfAgreementProcessImpl.class, iri, CLASS_OF_AGREEMENT_PROCESS);
     }
 
     /**
-     * Builder for ClassOfAgreementProcessImpl.
+     * Builder for constructing instances of ClassOfAgreementProcess.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAgreementProcessImpl classOfAgreementProcessImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAgreementProcess.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAgreementProcess.
          */
         public Builder(final IRI iri) {
             classOfAgreementProcessImpl = new ClassOfAgreementProcessImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAgreementProcessImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAgreementProcessImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAgreementProcessImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,14 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -141,9 +164,14 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -153,9 +181,11 @@ public class ClassOfAgreementProcessImpl extends HqdmObject implements ClassOfAg
         }
 
         /**
+         * Returns an instance of ClassOfAgreementProcess created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAgreementProcess.
+         * @throws HqdmException If the ClassOfAgreementProcess is missing any mandatory properties.
          */
         public ClassOfAgreementProcess build() throws HqdmException {
             if (classOfAgreementProcessImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAmountOfMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAmountOfMoneyImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmountOfMoney {
     /**
+     * Constructs a new ClassOfAmountOfMoney.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAmountOfMoney.
      */
     public ClassOfAmountOfMoneyImpl(final IRI iri) {
         super(ClassOfAmountOfMoneyImpl.class, iri, CLASS_OF_AMOUNT_OF_MONEY);
     }
 
     /**
-     * Builder for ClassOfAmountOfMoneyImpl.
+     * Builder for constructing instances of ClassOfAmountOfMoney.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAmountOfMoneyImpl classOfAmountOfMoneyImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAmountOfMoney.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAmountOfMoney.
          */
         public Builder(final IRI iri) {
             classOfAmountOfMoneyImpl = new ClassOfAmountOfMoneyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAmountOfMoneyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAmountOfMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAmountOfMoneyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfAmountOfMoneyImpl extends HqdmObject implements ClassOfAmoun
         }
 
         /**
+         * Returns an instance of ClassOfAmountOfMoney created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAmountOfMoney.
+         * @throws HqdmException If the ClassOfAmountOfMoney is missing any mandatory properties.
          */
         public ClassOfAmountOfMoney build() throws HqdmException {
             if (classOfAmountOfMoneyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfAssociationImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssociation {
     /**
+     * Constructs a new ClassOfAssociation.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfAssociation.
      */
     public ClassOfAssociationImpl(final IRI iri) {
         super(ClassOfAssociationImpl.class, iri, CLASS_OF_ASSOCIATION);
     }
 
     /**
-     * Builder for ClassOfAssociationImpl.
+     * Builder for constructing instances of ClassOfAssociation.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfAssociationImpl classOfAssociationImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfAssociation.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfAssociation.
          */
         public Builder(final IRI iri) {
             classOfAssociationImpl = new ClassOfAssociationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfAssociationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfAssociationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfAssociationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfAssociationImpl extends HqdmObject implements ClassOfAssocia
         }
 
         /**
+         * Returns an instance of ClassOfAssociation created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfAssociation.
+         * @throws HqdmException If the ClassOfAssociation is missing any mandatory properties.
          */
         public ClassOfAssociation build() throws HqdmException {
             if (classOfAssociationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBiologicalObject {
     /**
+     * Constructs a new ClassOfBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfBiologicalObject.
      */
     public ClassOfBiologicalObjectImpl(final IRI iri) {
         super(ClassOfBiologicalObjectImpl.class, iri, CLASS_OF_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfBiologicalObjectImpl.
+     * Builder for constructing instances of ClassOfBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfBiologicalObjectImpl classOfBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfBiologicalObject.
          */
         public Builder(final IRI iri) {
             classOfBiologicalObjectImpl = new ClassOfBiologicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfBiologicalObjectImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * Returns an instance of ClassOfBiologicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfBiologicalObject.
+         * @throws HqdmException If the ClassOfBiologicalObject is missing any mandatory properties.
          */
         public ClassOfBiologicalObject build() throws HqdmException {
             if (classOfBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalSystemComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         implements ClassOfBiologicalSystemComponent {
     /**
+     * Constructs a new ClassOfBiologicalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfBiologicalSystemComponent.
      */
     public ClassOfBiologicalSystemComponentImpl(final IRI iri) {
         super(ClassOfBiologicalSystemComponentImpl.class, iri,
@@ -46,24 +47,29 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfBiologicalSystemComponentImpl.
+     * Builder for constructing instances of ClassOfBiologicalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfBiologicalSystemComponentImpl classOfBiologicalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfBiologicalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfBiologicalSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfBiologicalSystemComponentImpl = new ClassOfBiologicalSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfBiologicalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfBiologicalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,9 +103,11 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfBiologicalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -103,9 +115,12 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -127,9 +145,12 @@ public class ClassOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfBiologicalSystemComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfBiologicalSystemComponent.
+         * @throws HqdmException If the ClassOfBiologicalSystemComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfBiologicalSystemComponent build() throws HqdmException {
             if (classOfBiologicalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfBiologicalSystemImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBiologicalSystem {
     /**
+     * Constructs a new ClassOfBiologicalSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfBiologicalSystem.
      */
     public ClassOfBiologicalSystemImpl(final IRI iri) {
         super(ClassOfBiologicalSystemImpl.class, iri, CLASS_OF_BIOLOGICAL_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfBiologicalSystemImpl.
+     * Builder for constructing instances of ClassOfBiologicalSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfBiologicalSystemImpl classOfBiologicalSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfBiologicalSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfBiologicalSystem.
          */
         public Builder(final IRI iri) {
             classOfBiologicalSystemImpl = new ClassOfBiologicalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfBiologicalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfBiologicalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfBiologicalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfBiologicalSystemImpl extends HqdmObject implements ClassOfBi
         }
 
         /**
+         * Returns an instance of ClassOfBiologicalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfBiologicalSystem.
+         * @throws HqdmException If the ClassOfBiologicalSystem is missing any mandatory properties.
          */
         public ClassOfBiologicalSystem build() throws HqdmException {
             if (classOfBiologicalSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfClassImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfClassImpl.java
@@ -30,32 +30,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfClassImpl extends HqdmObject implements ClassOfClass {
     /**
+     * Constructs a new ClassOfClass.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfClass.
      */
     public ClassOfClassImpl(final IRI iri) {
         super(ClassOfClassImpl.class, iri, CLASS_OF_CLASS);
     }
 
     /**
-     * Builder for ClassOfClassImpl.
+     * Builder for constructing instances of ClassOfClass.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfClassImpl classOfClassImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfClass.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfClass.
          */
         public Builder(final IRI iri) {
             classOfClassImpl = new ClassOfClassImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfClassImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -63,9 +67,11 @@ public class ClassOfClassImpl extends HqdmObject implements ClassOfClass {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfClassImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -73,9 +79,11 @@ public class ClassOfClassImpl extends HqdmObject implements ClassOfClass {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfClassImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -83,9 +91,10 @@ public class ClassOfClassImpl extends HqdmObject implements ClassOfClass {
         }
 
         /**
+         * Returns an instance of ClassOfClass created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfClass.
+         * @throws HqdmException If the ClassOfClass is missing any mandatory properties.
          */
         public ClassOfClass build() throws HqdmException {
             if (classOfClassImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfClassOfSpatioTemporalExtentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfClassOfSpatioTemporalExtentImpl.java
@@ -32,8 +32,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
         implements ClassOfClassOfSpatioTemporalExtent {
     /**
+     * Constructs a new ClassOfClassOfSpatioTemporalExtent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfClassOfSpatioTemporalExtent.
      */
     public ClassOfClassOfSpatioTemporalExtentImpl(final IRI iri) {
         super(ClassOfClassOfSpatioTemporalExtentImpl.class, iri,
@@ -41,15 +42,16 @@ public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfClassOfSpatioTemporalExtentImpl.
+     * Builder for constructing instances of ClassOfClassOfSpatioTemporalExtent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfClassOfSpatioTemporalExtentImpl classOfClassOfSpatioTemporalExtentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfClassOfSpatioTemporalExtent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfClassOfSpatioTemporalExtent.
          */
         public Builder(final IRI iri) {
             classOfClassOfSpatioTemporalExtentImpl =
@@ -57,9 +59,11 @@ public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfClassOfSpatioTemporalExtentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -67,9 +71,11 @@ public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfClassOfSpatioTemporalExtentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -77,9 +83,11 @@ public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfClassOfSpatioTemporalExtentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -87,9 +95,12 @@ public class ClassOfClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfClassOfSpatioTemporalExtent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfClassOfSpatioTemporalExtent.
+         * @throws HqdmException If the ClassOfClassOfSpatioTemporalExtent is missing any mandatory
+         *         properties.
          */
         public ClassOfClassOfSpatioTemporalExtent build() throws HqdmException {
             if (classOfClassOfSpatioTemporalExtentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfContractExecutionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfContractExecutionImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfContractExecution {
     /**
+     * Constructs a new ClassOfContractExecution.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfContractExecution.
      */
     public ClassOfContractExecutionImpl(final IRI iri) {
         super(ClassOfContractExecutionImpl.class, iri, CLASS_OF_CONTRACT_EXECUTION);
     }
 
     /**
-     * Builder for ClassOfContractExecutionImpl.
+     * Builder for constructing instances of ClassOfContractExecution.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfContractExecutionImpl classOfContractExecutionImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfContractExecution.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfContractExecution.
          */
         public Builder(final IRI iri) {
             classOfContractExecutionImpl = new ClassOfContractExecutionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfContractExecutionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfContractExecutionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfContractExecutionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,11 +147,13 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
-         * A part_of_by_class relationship type where a member_of the class_of_contract_execution
-         * may be a part_of a member_of the {@link ClassOfContractProcess}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link ClassOfContractExecution} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link ClassOfContractProcess}.
          *
-         * @param classOfContractProcess
-         * @return
+         * @param classOfContractProcess The ClassOfContractProcess.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfContractProcess classOfContractProcess) {
@@ -143,9 +163,14 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -155,9 +180,12 @@ public class ClassOfContractExecutionImpl extends HqdmObject implements ClassOfC
         }
 
         /**
+         * Returns an instance of ClassOfContractExecution created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfContractExecution.
+         * @throws HqdmException If the ClassOfContractExecution is missing any mandatory
+         *         properties.
          */
         public ClassOfContractExecution build() throws HqdmException {
             if (classOfContractExecutionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfContractProcessImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfContractProcessImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfContractProcess {
     /**
+     * Constructs a new ClassOfContractProcess.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfContractProcess.
      */
     public ClassOfContractProcessImpl(final IRI iri) {
         super(ClassOfContractProcessImpl.class, iri, CLASS_OF_CONTRACT_PROCESS);
     }
 
     /**
-     * Builder for ClassOfContractProcessImpl.
+     * Builder for constructing instances of ClassOfContractProcess.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfContractProcessImpl classOfContractProcessImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfContractProcess.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfContractProcess.
          */
         public Builder(final IRI iri) {
             classOfContractProcessImpl = new ClassOfContractProcessImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfContractProcessImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfContractProcessImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfContractProcessImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,14 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -141,9 +164,14 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -153,9 +181,11 @@ public class ClassOfContractProcessImpl extends HqdmObject implements ClassOfCon
         }
 
         /**
+         * Returns an instance of ClassOfContractProcess created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfContractProcess.
+         * @throws HqdmException If the ClassOfContractProcess is missing any mandatory properties.
          */
         public ClassOfContractProcess build() throws HqdmException {
             if (classOfContractProcessImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfEventImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfEventImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
     /**
+     * Constructs a new ClassOfEvent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfEvent.
      */
     public ClassOfEventImpl(final IRI iri) {
         super(ClassOfEventImpl.class, iri, CLASS_OF_EVENT);
     }
 
     /**
-     * Builder for ClassOfEventImpl.
+     * Builder for constructing instances of ClassOfEvent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfEventImpl classOfEventImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfEvent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfEvent.
          */
         public Builder(final IRI iri) {
             classOfEventImpl = new ClassOfEventImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfEventImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfEventImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfEventImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class ClassOfEventImpl extends HqdmObject implements ClassOfEvent {
         }
 
         /**
+         * Returns an instance of ClassOfEvent created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfEvent.
+         * @throws HqdmException If the ClassOfEvent is missing any mandatory properties.
          */
         public ClassOfEvent build() throws HqdmException {
             if (classOfEventImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFunctionalObject {
     /**
+     * Constructs a new ClassOfFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfFunctionalObject.
      */
     public ClassOfFunctionalObjectImpl(final IRI iri) {
         super(ClassOfFunctionalObjectImpl.class, iri, CLASS_OF_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfFunctionalObjectImpl.
+     * Builder for constructing instances of ClassOfFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfFunctionalObjectImpl classOfFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfFunctionalObject.
          */
         public Builder(final IRI iri) {
             classOfFunctionalObjectImpl = new ClassOfFunctionalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfFunctionalObjectImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * Returns an instance of ClassOfFunctionalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfFunctionalObject.
+         * @throws HqdmException If the ClassOfFunctionalObject is missing any mandatory properties.
          */
         public ClassOfFunctionalObject build() throws HqdmException {
             if (classOfFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalSystemComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         implements ClassOfFunctionalSystemComponent {
     /**
+     * Constructs a new ClassOfFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfFunctionalSystemComponent.
      */
     public ClassOfFunctionalSystemComponentImpl(final IRI iri) {
         super(ClassOfFunctionalSystemComponentImpl.class, iri,
@@ -46,24 +47,29 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfFunctionalSystemComponentImpl.
+     * Builder for constructing instances of ClassOfFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfFunctionalSystemComponentImpl classOfFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfFunctionalSystemComponentImpl = new ClassOfFunctionalSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfFunctionalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,9 +103,11 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfFunctionalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -103,9 +115,12 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -127,9 +145,12 @@ public class ClassOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfFunctionalSystemComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfFunctionalSystemComponent.
+         * @throws HqdmException If the ClassOfFunctionalSystemComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfFunctionalSystemComponent build() throws HqdmException {
             if (classOfFunctionalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfFunctionalSystemImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFunctionalSystem {
     /**
+     * Constructs a new ClassOfFunctionalSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfFunctionalSystem.
      */
     public ClassOfFunctionalSystemImpl(final IRI iri) {
         super(ClassOfFunctionalSystemImpl.class, iri, CLASS_OF_FUNCTIONAL_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfFunctionalSystemImpl.
+     * Builder for constructing instances of ClassOfFunctionalSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfFunctionalSystemImpl classOfFunctionalSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfFunctionalSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfFunctionalSystem.
          */
         public Builder(final IRI iri) {
             classOfFunctionalSystemImpl = new ClassOfFunctionalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfFunctionalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfFunctionalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfFunctionalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfFunctionalSystemImpl extends HqdmObject implements ClassOfFu
         }
 
         /**
+         * Returns an instance of ClassOfFunctionalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfFunctionalSystem.
+         * @throws HqdmException If the ClassOfFunctionalSystem is missing any mandatory properties.
          */
         public ClassOfFunctionalSystem build() throws HqdmException {
             if (classOfFunctionalSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInPlaceBiologicalComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInPlaceBiologicalComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         implements ClassOfInPlaceBiologicalComponent {
     /**
+     * Constructs a new ClassOfInPlaceBiologicalComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfInPlaceBiologicalComponent.
      */
     public ClassOfInPlaceBiologicalComponentImpl(final IRI iri) {
         super(ClassOfInPlaceBiologicalComponentImpl.class, iri,
@@ -46,24 +47,29 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfInPlaceBiologicalComponentImpl.
+     * Builder for constructing instances of ClassOfInPlaceBiologicalComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfInPlaceBiologicalComponentImpl classOfInPlaceBiologicalComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfInPlaceBiologicalComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfInPlaceBiologicalComponent.
          */
         public Builder(final IRI iri) {
             classOfInPlaceBiologicalComponentImpl = new ClassOfInPlaceBiologicalComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfInPlaceBiologicalComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfInPlaceBiologicalComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,9 +103,11 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfInPlaceBiologicalComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -103,9 +115,12 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -127,9 +145,12 @@ public class ClassOfInPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfInPlaceBiologicalComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfInPlaceBiologicalComponent.
+         * @throws HqdmException If the ClassOfInPlaceBiologicalComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfInPlaceBiologicalComponent build() throws HqdmException {
             if (classOfInPlaceBiologicalComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfIndividualImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfIndividualImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividual {
     /**
+     * Constructs a new ClassOfIndividual.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfIndividual.
      */
     public ClassOfIndividualImpl(final IRI iri) {
         super(ClassOfIndividualImpl.class, iri, CLASS_OF_INDIVIDUAL);
     }
 
     /**
-     * Builder for ClassOfIndividualImpl.
+     * Builder for constructing instances of ClassOfIndividual.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfIndividualImpl classOfIndividualImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfIndividual.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfIndividual.
          */
         public Builder(final IRI iri) {
             classOfIndividualImpl = new ClassOfIndividualImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfIndividualImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfIndividualImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfIndividualImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class ClassOfIndividualImpl extends HqdmObject implements ClassOfIndividu
         }
 
         /**
+         * Returns an instance of ClassOfIndividual created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfIndividual.
+         * @throws HqdmException If the ClassOfIndividual is missing any mandatory properties.
          */
         public ClassOfIndividual build() throws HqdmException {
             if (classOfIndividualImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInstalledFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInstalledFunctionalSystemComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         implements ClassOfInstalledFunctionalSystemComponent {
     /**
+     * Constructs a new ClassOfInstalledFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfInstalledFunctionalSystemComponent.
      */
     public ClassOfInstalledFunctionalSystemComponentImpl(final IRI iri) {
         super(ClassOfInstalledFunctionalSystemComponentImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfInstalledFunctionalSystemComponentImpl.
+     * Builder for constructing instances of ClassOfInstalledFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfInstalledFunctionalSystemComponentImpl classOfInstalledFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfInstalledFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfInstalledFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfInstalledFunctionalSystemComponentImpl =
@@ -63,9 +65,13 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfInstalledFunctionalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfInstalledFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfInstalledFunctionalSystemComponentImpl.addValue(MEMBER_OF,
@@ -106,9 +118,12 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -118,9 +133,12 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -130,9 +148,12 @@ public class ClassOfInstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfInstalledFunctionalSystemComponent created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfInstalledFunctionalSystemComponent.
+         * @throws HqdmException If the ClassOfInstalledFunctionalSystemComponent is missing any
+         *         mandatory properties.
          */
         public ClassOfInstalledFunctionalSystemComponent build() throws HqdmException {
             if (classOfInstalledFunctionalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInstalledObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfInstalledObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfInstalledObject {
     /**
+     * Constructs a new ClassOfInstalledObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfInstalledObject.
      */
     public ClassOfInstalledObjectImpl(final IRI iri) {
         super(ClassOfInstalledObjectImpl.class, iri, CLASS_OF_INSTALLED_OBJECT);
     }
 
     /**
-     * Builder for ClassOfInstalledObjectImpl.
+     * Builder for constructing instances of ClassOfInstalledObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfInstalledObjectImpl classOfInstalledObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfInstalledObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfInstalledObject.
          */
         public Builder(final IRI iri) {
             classOfInstalledObjectImpl = new ClassOfInstalledObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfInstalledObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfInstalledObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfInstalledObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfInstalledObjectImpl extends HqdmObject implements ClassOfIns
         }
 
         /**
+         * Returns an instance of ClassOfInstalledObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfInstalledObject.
+         * @throws HqdmException If the ClassOfInstalledObject is missing any mandatory properties.
          */
         public ClassOfInstalledObject build() throws HqdmException {
             if (classOfInstalledObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfIntentionallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfIntentionallyConstructedObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         implements ClassOfIntentionallyConstructedObject {
     /**
+     * Constructs a new ClassOfIntentionallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfIntentionallyConstructedObject.
      */
     public ClassOfIntentionallyConstructedObjectImpl(final IRI iri) {
         super(ClassOfIntentionallyConstructedObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfIntentionallyConstructedObjectImpl.
+     * Builder for constructing instances of ClassOfIntentionallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfIntentionallyConstructedObjectImpl classOfIntentionallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfIntentionallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfIntentionallyConstructedObject.
          */
         public Builder(final IRI iri) {
             classOfIntentionallyConstructedObjectImpl =
@@ -63,9 +65,13 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfIntentionallyConstructedObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfIntentionallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfIntentionallyConstructedObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfIntentionallyConstructedObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfIntentionallyConstructedObject.
+         * @throws HqdmException If the ClassOfIntentionallyConstructedObject is missing any
+         *         mandatory properties.
          */
         public ClassOfIntentionallyConstructedObject build() throws HqdmException {
             if (classOfIntentionallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOfferImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOfferImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
     /**
+     * Constructs a new ClassOfOffer.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOffer.
      */
     public ClassOfOfferImpl(final IRI iri) {
         super(ClassOfOfferImpl.class, iri, CLASS_OF_OFFER);
     }
 
     /**
-     * Builder for ClassOfOfferImpl.
+     * Builder for constructing instances of ClassOfOffer.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOfferImpl classOfOfferImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOffer.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOffer.
          */
         public Builder(final IRI iri) {
             classOfOfferImpl = new ClassOfOfferImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOfferImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +92,11 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOfferImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -94,9 +104,11 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOfferImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -104,9 +116,12 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,14 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -137,9 +160,14 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -148,9 +176,10 @@ public class ClassOfOfferImpl extends HqdmObject implements ClassOfOffer {
         }
 
         /**
+         * Returns an instance of ClassOfOffer created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOffer.
+         * @throws HqdmException If the ClassOfOffer is missing any mandatory properties.
          */
         public ClassOfOffer build() throws HqdmException {
             if (classOfOfferImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryBiologicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         implements ClassOfOrdinaryBiologicalObject {
     /**
+     * Constructs a new ClassOfOrdinaryBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOrdinaryBiologicalObject.
      */
     public ClassOfOrdinaryBiologicalObjectImpl(final IRI iri) {
         super(ClassOfOrdinaryBiologicalObjectImpl.class, iri, CLASS_OF_ORDINARY_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfOrdinaryBiologicalObjectImpl.
+     * Builder for constructing instances of ClassOfOrdinaryBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOrdinaryBiologicalObjectImpl classOfOrdinaryBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOrdinaryBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOrdinaryBiologicalObject.
          */
         public Builder(final IRI iri) {
             classOfOrdinaryBiologicalObjectImpl = new ClassOfOrdinaryBiologicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOrdinaryBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOrdinaryBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOrdinaryBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfOrdinaryBiologicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOrdinaryBiologicalObject.
+         * @throws HqdmException If the ClassOfOrdinaryBiologicalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfOrdinaryBiologicalObject build() throws HqdmException {
             if (classOfOrdinaryBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryFunctionalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         implements ClassOfOrdinaryFunctionalObject {
     /**
+     * Constructs a new ClassOfOrdinaryFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOrdinaryFunctionalObject.
      */
     public ClassOfOrdinaryFunctionalObjectImpl(final IRI iri) {
         super(ClassOfOrdinaryFunctionalObjectImpl.class, iri, CLASS_OF_ORDINARY_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfOrdinaryFunctionalObjectImpl.
+     * Builder for constructing instances of ClassOfOrdinaryFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOrdinaryFunctionalObjectImpl classOfOrdinaryFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOrdinaryFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOrdinaryFunctionalObject.
          */
         public Builder(final IRI iri) {
             classOfOrdinaryFunctionalObjectImpl = new ClassOfOrdinaryFunctionalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOrdinaryFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOrdinaryFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOrdinaryFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfOrdinaryFunctionalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOrdinaryFunctionalObject.
+         * @throws HqdmException If the ClassOfOrdinaryFunctionalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfOrdinaryFunctionalObject build() throws HqdmException {
             if (classOfOrdinaryFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrdinaryPhysicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         implements ClassOfOrdinaryPhysicalObject {
     /**
+     * Constructs a new ClassOfOrdinaryPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOrdinaryPhysicalObject.
      */
     public ClassOfOrdinaryPhysicalObjectImpl(final IRI iri) {
         super(ClassOfOrdinaryPhysicalObjectImpl.class, iri, CLASS_OF_ORDINARY_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfOrdinaryPhysicalObjectImpl.
+     * Builder for constructing instances of ClassOfOrdinaryPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOrdinaryPhysicalObjectImpl classOfOrdinaryPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOrdinaryPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOrdinaryPhysicalObject.
          */
         public Builder(final IRI iri) {
             classOfOrdinaryPhysicalObjectImpl = new ClassOfOrdinaryPhysicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOrdinaryPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOrdinaryPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOrdinaryPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfOrdinaryPhysicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOrdinaryPhysicalObject.
+         * @throws HqdmException If the ClassOfOrdinaryPhysicalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfOrdinaryPhysicalObject build() throws HqdmException {
             if (classOfOrdinaryPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrganizationComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrganizationComponentImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfOrganizationComponentImpl extends HqdmObject
         implements ClassOfOrganizationComponent {
     /**
+     * Constructs a new ClassOfOrganizationComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOrganizationComponent.
      */
     public ClassOfOrganizationComponentImpl(final IRI iri) {
         super(ClassOfOrganizationComponentImpl.class, iri, CLASS_OF_ORGANIZATION_COMPONENT);
     }
 
     /**
-     * Builder for ClassOfOrganizationComponentImpl.
+     * Builder for constructing instances of ClassOfOrganizationComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOrganizationComponentImpl classOfOrganizationComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOrganizationComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOrganizationComponent.
          */
         public Builder(final IRI iri) {
             classOfOrganizationComponentImpl = new ClassOfOrganizationComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOrganizationComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOrganizationComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOrganizationComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfOrganizationComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOrganizationComponent.
+         * @throws HqdmException If the ClassOfOrganizationComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfOrganizationComponent build() throws HqdmException {
             if (classOfOrganizationComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrganizationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfOrganizationImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrganization {
     /**
+     * Constructs a new ClassOfOrganization.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfOrganization.
      */
     public ClassOfOrganizationImpl(final IRI iri) {
         super(ClassOfOrganizationImpl.class, iri, CLASS_OF_ORGANIZATION);
     }
 
     /**
-     * Builder for ClassOfOrganizationImpl.
+     * Builder for constructing instances of ClassOfOrganization.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfOrganizationImpl classOfOrganizationImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfOrganization.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfOrganization.
          */
         public Builder(final IRI iri) {
             classOfOrganizationImpl = new ClassOfOrganizationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfOrganizationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfOrganizationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfOrganizationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfOrganizationImpl extends HqdmObject implements ClassOfOrgani
         }
 
         /**
+         * Returns an instance of ClassOfOrganization created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfOrganization.
+         * @throws HqdmException If the ClassOfOrganization is missing any mandatory properties.
          */
         public ClassOfOrganization build() throws HqdmException {
             if (classOfOrganizationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfParticipantImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfParticipantImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfParticipantImpl extends HqdmObject implements ClassOfParticipant {
     /**
+     * Constructs a new ClassOfParticipant.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfParticipant.
      */
     public ClassOfParticipantImpl(final IRI iri) {
         super(ClassOfParticipantImpl.class, iri, CLASS_OF_PARTICIPANT);
     }
 
     /**
-     * Builder for ClassOfParticipantImpl.
+     * Builder for constructing instances of ClassOfParticipant.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfParticipantImpl classOfParticipantImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfParticipant.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfParticipant.
          */
         public Builder(final IRI iri) {
             classOfParticipantImpl = new ClassOfParticipantImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfParticipantImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfParticipantImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfParticipantImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfParticipantImpl extends HqdmObject implements ClassOfPartici
         }
 
         /**
+         * Returns an instance of ClassOfParticipant created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfParticipant.
+         * @throws HqdmException If the ClassOfParticipant is missing any mandatory properties.
          */
         public ClassOfParticipant build() throws HqdmException {
             if (classOfParticipantImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPartyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPartyImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
     /**
+     * Constructs a new ClassOfParty.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfParty.
      */
     public ClassOfPartyImpl(final IRI iri) {
         super(ClassOfPartyImpl.class, iri, CLASS_OF_PARTY);
     }
 
     /**
-     * Builder for ClassOfPartyImpl.
+     * Builder for constructing instances of ClassOfParty.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPartyImpl classOfPartyImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfParty.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfParty.
          */
         public Builder(final IRI iri) {
             classOfPartyImpl = new ClassOfPartyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPartyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPartyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPartyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ClassOfPartyImpl extends HqdmObject implements ClassOfParty {
         }
 
         /**
+         * Returns an instance of ClassOfParty created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfParty.
+         * @throws HqdmException If the ClassOfParty is missing any mandatory properties.
          */
         public ClassOfParty build() throws HqdmException {
             if (classOfPartyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPeriodOfTimeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPeriodOfTimeImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriodOfTime {
     /**
+     * Constructs a new ClassOfPeriodOfTime.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPeriodOfTime.
      */
     public ClassOfPeriodOfTimeImpl(final IRI iri) {
         super(ClassOfPeriodOfTimeImpl.class, iri, CLASS_OF_PERIOD_OF_TIME);
     }
 
     /**
-     * Builder for ClassOfPeriodOfTimeImpl.
+     * Builder for constructing instances of ClassOfPeriodOfTime.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPeriodOfTimeImpl classOfPeriodOfTimeImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPeriodOfTime.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPeriodOfTime.
          */
         public Builder(final IRI iri) {
             classOfPeriodOfTimeImpl = new ClassOfPeriodOfTimeImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPeriodOfTimeImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPeriodOfTimeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPeriodOfTimeImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfPeriodOfTimeImpl extends HqdmObject implements ClassOfPeriod
         }
 
         /**
+         * Returns an instance of ClassOfPeriodOfTime created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPeriodOfTime.
+         * @throws HqdmException If the ClassOfPeriodOfTime is missing any mandatory properties.
          */
         public ClassOfPeriodOfTime build() throws HqdmException {
             if (classOfPeriodOfTimeImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPersonImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPersonImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
     /**
+     * Constructs a new ClassOfPerson.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPerson.
      */
     public ClassOfPersonImpl(final IRI iri) {
         super(ClassOfPersonImpl.class, iri, CLASS_OF_PERSON);
     }
 
     /**
-     * Builder for ClassOfPersonImpl.
+     * Builder for constructing instances of ClassOfPerson.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPersonImpl classOfPersonImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPerson.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPerson.
          */
         public Builder(final IRI iri) {
             classOfPersonImpl = new ClassOfPersonImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPersonImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPersonImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPersonImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ClassOfPersonImpl extends HqdmObject implements ClassOfPerson {
         }
 
         /**
+         * Returns an instance of ClassOfPerson created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPerson.
+         * @throws HqdmException If the ClassOfPerson is missing any mandatory properties.
          */
         public ClassOfPerson build() throws HqdmException {
             if (classOfPersonImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPersonInPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPersonInPositionImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPersonInPosition {
     /**
+     * Constructs a new ClassOfPersonInPosition.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPersonInPosition.
      */
     public ClassOfPersonInPositionImpl(final IRI iri) {
         super(ClassOfPersonInPositionImpl.class, iri, CLASS_OF_PERSON_IN_POSITION);
     }
 
     /**
-     * Builder for ClassOfPersonInPositionImpl.
+     * Builder for constructing instances of ClassOfPersonInPosition.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPersonInPositionImpl classOfPersonInPositionImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPersonInPosition.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPersonInPosition.
          */
         public Builder(final IRI iri) {
             classOfPersonInPositionImpl = new ClassOfPersonInPositionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPersonInPositionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPersonInPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPersonInPositionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfPersonInPositionImpl extends HqdmObject implements ClassOfPe
         }
 
         /**
+         * Returns an instance of ClassOfPersonInPosition created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPersonInPosition.
+         * @throws HqdmException If the ClassOfPersonInPosition is missing any mandatory properties.
          */
         public ClassOfPersonInPosition build() throws HqdmException {
             if (classOfPersonInPositionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhysicalObject {
     /**
+     * Constructs a new ClassOfPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPhysicalObject.
      */
     public ClassOfPhysicalObjectImpl(final IRI iri) {
         super(ClassOfPhysicalObjectImpl.class, iri, CLASS_OF_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfPhysicalObjectImpl.
+     * Builder for constructing instances of ClassOfPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPhysicalObjectImpl classOfPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPhysicalObject.
          */
         public Builder(final IRI iri) {
             classOfPhysicalObjectImpl = new ClassOfPhysicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfPhysicalObjectImpl extends HqdmObject implements ClassOfPhys
         }
 
         /**
+         * Returns an instance of ClassOfPhysicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPhysicalObject.
+         * @throws HqdmException If the ClassOfPhysicalObject is missing any mandatory properties.
          */
         public ClassOfPhysicalObject build() throws HqdmException {
             if (classOfPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalPropertyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalPropertyImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPhysicalPropertyImpl extends HqdmObject implements ClassOfPhysicalProperty {
     /**
+     * Constructs a new ClassOfPhysicalProperty.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPhysicalProperty.
      */
     public ClassOfPhysicalPropertyImpl(final IRI iri) {
         super(ClassOfPhysicalPropertyImpl.class, iri, CLASS_OF_PHYSICAL_PROPERTY);
     }
 
     /**
-     * Builder for ClassOfPhysicalPropertyImpl.
+     * Builder for constructing instances of ClassOfPhysicalProperty.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPhysicalPropertyImpl classOfPhysicalPropertyImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPhysicalProperty.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPhysicalProperty.
          */
         public Builder(final IRI iri) {
             classOfPhysicalPropertyImpl = new ClassOfPhysicalPropertyImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPhysicalPropertyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class ClassOfPhysicalPropertyImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPhysicalPropertyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class ClassOfPhysicalPropertyImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPhysicalPropertyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class ClassOfPhysicalPropertyImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * Returns an instance of ClassOfPhysicalProperty created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPhysicalProperty.
+         * @throws HqdmException If the ClassOfPhysicalProperty is missing any mandatory properties.
          */
         public ClassOfPhysicalProperty build() throws HqdmException {
             if (classOfPhysicalPropertyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalQuantityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPhysicalQuantityImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPhysicalQuantityImpl extends HqdmObject implements ClassOfPhysicalQuantity {
     /**
+     * Constructs a new ClassOfPhysicalQuantity.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPhysicalQuantity.
      */
     public ClassOfPhysicalQuantityImpl(final IRI iri) {
         super(ClassOfPhysicalQuantityImpl.class, iri, CLASS_OF_PHYSICAL_QUANTITY);
     }
 
     /**
-     * Builder for ClassOfPhysicalQuantityImpl.
+     * Builder for constructing instances of ClassOfPhysicalQuantity.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPhysicalQuantityImpl classOfPhysicalQuantityImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPhysicalQuantity.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPhysicalQuantity.
          */
         public Builder(final IRI iri) {
             classOfPhysicalQuantityImpl = new ClassOfPhysicalQuantityImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPhysicalQuantityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class ClassOfPhysicalQuantityImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPhysicalQuantityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class ClassOfPhysicalQuantityImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPhysicalQuantityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class ClassOfPhysicalQuantityImpl extends HqdmObject implements ClassOfPh
         }
 
         /**
+         * Returns an instance of ClassOfPhysicalQuantity created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPhysicalQuantity.
+         * @throws HqdmException If the ClassOfPhysicalQuantity is missing any mandatory properties.
          */
         public ClassOfPhysicalQuantity build() throws HqdmException {
             if (classOfPhysicalQuantityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPointInTimeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPointInTimeImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointInTime {
     /**
+     * Constructs a new ClassOfPointInTime.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPointInTime.
      */
     public ClassOfPointInTimeImpl(final IRI iri) {
         super(ClassOfPointInTimeImpl.class, iri, CLASS_OF_POINT_IN_TIME);
     }
 
     /**
-     * Builder for ClassOfPointInTimeImpl.
+     * Builder for constructing instances of ClassOfPointInTime.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPointInTimeImpl classOfPointInTimeImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPointInTime.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPointInTime.
          */
         public Builder(final IRI iri) {
             classOfPointInTimeImpl = new ClassOfPointInTimeImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPointInTimeImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPointInTimeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPointInTimeImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfPointInTimeImpl extends HqdmObject implements ClassOfPointIn
         }
 
         /**
+         * Returns an instance of ClassOfPointInTime created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPointInTime.
+         * @throws HqdmException If the ClassOfPointInTime is missing any mandatory properties.
          */
         public ClassOfPointInTime build() throws HqdmException {
             if (classOfPointInTimeImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPositionImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
     /**
+     * Constructs a new ClassOfPosition.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPosition.
      */
     public ClassOfPositionImpl(final IRI iri) {
         super(ClassOfPositionImpl.class, iri, CLASS_OF_POSITION);
     }
 
     /**
-     * Builder for ClassOfPositionImpl.
+     * Builder for constructing instances of ClassOfPosition.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPositionImpl classOfPositionImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPosition.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPosition.
          */
         public Builder(final IRI iri) {
             classOfPositionImpl = new ClassOfPositionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPositionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPositionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class ClassOfPositionImpl extends HqdmObject implements ClassOfPosition {
         }
 
         /**
+         * Returns an instance of ClassOfPosition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPosition.
+         * @throws HqdmException If the ClassOfPosition is missing any mandatory properties.
          */
         public ClassOfPosition build() throws HqdmException {
             if (classOfPositionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPossibleWorldImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfPossibleWorldImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossibleWorld {
     /**
+     * Constructs a new ClassOfPossibleWorld.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfPossibleWorld.
      */
     public ClassOfPossibleWorldImpl(final IRI iri) {
         super(ClassOfPossibleWorldImpl.class, iri, CLASS_OF_POSSIBLE_WORLD);
     }
 
     /**
-     * Builder for ClassOfPossibleWorldImpl.
+     * Builder for constructing instances of ClassOfPossibleWorld.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfPossibleWorldImpl classOfPossibleWorldImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfPossibleWorld.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfPossibleWorld.
          */
         public Builder(final IRI iri) {
             classOfPossibleWorldImpl = new ClassOfPossibleWorldImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfPossibleWorldImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfPossibleWorldImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfPossibleWorldImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfPossibleWorldImpl extends HqdmObject implements ClassOfPossi
         }
 
         /**
+         * Returns an instance of ClassOfPossibleWorld created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfPossibleWorld.
+         * @throws HqdmException If the ClassOfPossibleWorld is missing any mandatory properties.
          */
         public ClassOfPossibleWorld build() throws HqdmException {
             if (classOfPossibleWorldImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfReachingAgreementImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfReachingAgreementImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfReachingAgreement {
     /**
+     * Constructs a new ClassOfReachingAgreement.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfReachingAgreement.
      */
     public ClassOfReachingAgreementImpl(final IRI iri) {
         super(ClassOfReachingAgreementImpl.class, iri, CLASS_OF_REACHING_AGREEMENT);
     }
 
     /**
-     * Builder for ClassOfReachingAgreementImpl.
+     * Builder for constructing instances of ClassOfReachingAgreement.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfReachingAgreementImpl classOfReachingAgreementImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfReachingAgreement.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfReachingAgreement.
          */
         public Builder(final IRI iri) {
             classOfReachingAgreementImpl = new ClassOfReachingAgreementImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfReachingAgreementImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfReachingAgreementImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfReachingAgreementImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,11 +147,13 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
-         * A part_of_by_class relationship type where a member_of a class_of_reaching_agreement may
-         * be a part_of a member_of a {@link ClassOfAgreementProcess}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfReachingAgreement} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementProcess}.
          *
-         * @param classOfAgreementProcess
-         * @return
+         * @param classOfAgreementProcess The ClassOfAgreementProcess.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfAgreementProcess classOfAgreementProcess) {
@@ -143,9 +163,14 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -155,9 +180,12 @@ public class ClassOfReachingAgreementImpl extends HqdmObject implements ClassOfR
         }
 
         /**
+         * Returns an instance of ClassOfReachingAgreement created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfReachingAgreement.
+         * @throws HqdmException If the ClassOfReachingAgreement is missing any mandatory
+         *         properties.
          */
         public ClassOfReachingAgreement build() throws HqdmException {
             if (classOfReachingAgreementImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRelationshipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRelationshipImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfRelationshipImpl extends HqdmObject implements ClassOfRelationship {
     /**
+     * Constructs a new ClassOfRelationship.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfRelationship.
      */
     public ClassOfRelationshipImpl(final IRI iri) {
         super(ClassOfRelationshipImpl.class, iri, CLASS_OF_RELATIONSHIP);
     }
 
     /**
-     * Builder for ClassOfRelationshipImpl.
+     * Builder for constructing instances of ClassOfRelationship.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfRelationshipImpl classOfRelationshipImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfRelationship.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfRelationship.
          */
         public Builder(final IRI iri) {
             classOfRelationshipImpl = new ClassOfRelationshipImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfRelationshipImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class ClassOfRelationshipImpl extends HqdmObject implements ClassOfRelati
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfRelationshipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class ClassOfRelationshipImpl extends HqdmObject implements ClassOfRelati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfRelationshipImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class ClassOfRelationshipImpl extends HqdmObject implements ClassOfRelati
         }
 
         /**
+         * Returns an instance of ClassOfRelationship created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfRelationship.
+         * @throws HqdmException If the ClassOfRelationship is missing any mandatory properties.
          */
         public ClassOfRelationship build() throws HqdmException {
             if (classOfRelationshipImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRepresentationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfRepresentationImpl.java
@@ -28,32 +28,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfRepresentationImpl extends HqdmObject implements ClassOfRepresentation {
     /**
+     * Constructs a new ClassOfRepresentation.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfRepresentation.
      */
     public ClassOfRepresentationImpl(final IRI iri) {
         super(ClassOfRepresentationImpl.class, iri, CLASS_OF_REPRESENTATION);
     }
 
     /**
-     * Builder for ClassOfRepresentationImpl.
+     * Builder for constructing instances of ClassOfRepresentation.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfRepresentationImpl classOfRepresentationImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfRepresentation.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfRepresentation.
          */
         public Builder(final IRI iri) {
             classOfRepresentationImpl = new ClassOfRepresentationImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz the Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfRepresentationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -61,9 +65,11 @@ public class ClassOfRepresentationImpl extends HqdmObject implements ClassOfRepr
         }
 
         /**
+         * Returns an instance of ClassOfRepresentation created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfRepresentation.
+         * @throws HqdmException If the ClassOfRepresentation is missing any mandatory properties.
          */
         public ClassOfRepresentation build() throws HqdmException {
             if (classOfRepresentationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSalesProductInstanceImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSalesProductInstanceImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfSalesProductInstanceImpl extends HqdmObject
         implements ClassOfSalesProductInstance {
     /**
+     * Constructs a new ClassOfSalesProductInstance.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSalesProductInstance.
      */
     public ClassOfSalesProductInstanceImpl(final IRI iri) {
         super(ClassOfSalesProductInstanceImpl.class, iri, CLASS_OF_SALES_PRODUCT_INSTANCE);
     }
 
     /**
-     * Builder for ClassOfSalesProductInstanceImpl.
+     * Builder for constructing instances of ClassOfSalesProductInstance.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSalesProductInstanceImpl classOfSalesProductInstanceImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSalesProductInstance.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSalesProductInstance.
          */
         public Builder(final IRI iri) {
             classOfSalesProductInstanceImpl = new ClassOfSalesProductInstanceImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSalesProductInstanceImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSalesProductInstanceImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSalesProductInstanceImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfSalesProductInstance created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSalesProductInstance.
+         * @throws HqdmException If the ClassOfSalesProductInstance is missing any mandatory
+         *         properties.
          */
         public ClassOfSalesProductInstance build() throws HqdmException {
             if (classOfSalesProductInstanceImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSignImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSignImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
     /**
+     * Constructs a new ClassOfSign.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSign.
      */
     public ClassOfSignImpl(final IRI iri) {
         super(ClassOfSignImpl.class, iri, CLASS_OF_SIGN);
     }
 
     /**
-     * Builder for ClassOfSignImpl.
+     * Builder for constructing instances of ClassOfSign.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSignImpl classOfSignImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSign.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSign.
          */
         public Builder(final IRI iri) {
             classOfSignImpl = new ClassOfSignImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSignImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSignImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSignImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ClassOfSignImpl extends HqdmObject implements ClassOfSign {
         }
 
         /**
+         * Returns an instance of ClassOfSign created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSign.
+         * @throws HqdmException If the ClassOfSign is missing any mandatory properties.
          */
         public ClassOfSign build() throws HqdmException {
             if (classOfSignImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSociallyConstructedActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSociallyConstructedActivityImpl.java
@@ -41,8 +41,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         implements ClassOfSociallyConstructedActivity {
     /**
+     * Constructs a new ClassOfSociallyConstructedActivity.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSociallyConstructedActivity.
      */
     public ClassOfSociallyConstructedActivityImpl(final IRI iri) {
         super(ClassOfSociallyConstructedActivityImpl.class, iri,
@@ -50,15 +51,16 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfSociallyConstructedActivityImpl.
+     * Builder for constructing instances of ClassOfSociallyConstructedActivity.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSociallyConstructedActivityImpl classOfSociallyConstructedActivityImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSociallyConstructedActivity.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSociallyConstructedActivity.
          */
         public Builder(final IRI iri) {
             classOfSociallyConstructedActivityImpl =
@@ -66,9 +68,13 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -78,9 +84,11 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSociallyConstructedActivityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -88,9 +96,11 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSociallyConstructedActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -98,9 +108,11 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSociallyConstructedActivityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -108,9 +120,12 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -120,9 +135,12 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -132,11 +150,13 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
-         * A part_of_by_class where a member_of a class_of_socially_constructed_activity may be a
-         * part_of a member_of a {@link ClassOfReachingAgreement}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSociallyConstructedActivity}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -146,12 +166,13 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
-         * A part_of_by_class relationship type where a member_of a
-         * class_of_socially_constructed_activity may be a part_of a member_of a
-         * {@link ClassOfAgreementExecution}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSociallyConstructedActivity}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -161,9 +182,12 @@ public class ClassOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfSociallyConstructedActivity created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSociallyConstructedActivity.
+         * @throws HqdmException If the ClassOfSociallyConstructedActivity is missing any mandatory
+         *         properties.
          */
         public ClassOfSociallyConstructedActivity build() throws HqdmException {
             if (classOfSociallyConstructedActivityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSociallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSociallyConstructedObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         implements ClassOfSociallyConstructedObject {
     /**
+     * Constructs a new ClassOfSociallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSociallyConstructedObject.
      */
     public ClassOfSociallyConstructedObjectImpl(final IRI iri) {
         super(ClassOfSociallyConstructedObjectImpl.class, iri,
@@ -46,24 +47,29 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfSociallyConstructedObjectImpl.
+     * Builder for constructing instances of ClassOfSociallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSociallyConstructedObjectImpl classOfSociallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSociallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSociallyConstructedObject.
          */
         public Builder(final IRI iri) {
             classOfSociallyConstructedObjectImpl = new ClassOfSociallyConstructedObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSociallyConstructedObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSociallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,9 +103,11 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSociallyConstructedObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -103,9 +115,12 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -127,9 +145,12 @@ public class ClassOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfSociallyConstructedObject created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSociallyConstructedObject.
+         * @throws HqdmException If the ClassOfSociallyConstructedObject is missing any mandatory
+         *         properties.
          */
         public ClassOfSociallyConstructedObject build() throws HqdmException {
             if (classOfSociallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSpatioTemporalExtentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSpatioTemporalExtentImpl.java
@@ -36,35 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         implements ClassOfSpatioTemporalExtent {
     /**
+     * Constructs a new ClassOfSpatioTemporalExtent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSpatioTemporalExtent.
      */
     public ClassOfSpatioTemporalExtentImpl(final IRI iri) {
         super(ClassOfSpatioTemporalExtentImpl.class, iri, CLASS_OF_SPATIO_TEMPORAL_EXTENT);
     }
 
     /**
-     * Builder for ClassOfSpatioTemporalExtentImpl.
+     * Builder for constructing instances of ClassOfSpatioTemporalExtent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSpatioTemporalExtentImpl classOfSpatioTemporalExtentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSpatioTemporalExtent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSpatioTemporalExtent.
          */
         public Builder(final IRI iri) {
             classOfSpatioTemporalExtentImpl = new ClassOfSpatioTemporalExtentImpl(iri);
         }
 
         /**
-         * An inverse part__of_by_class relationship type where a member_of one
-         * class_of_spatio_temporal_extent consists_of another member_of a
-         * class_of_spatio_temporal_extent.
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +77,11 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSpatioTemporalExtentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +89,11 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSpatioTemporalExtentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -94,9 +101,11 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSpatioTemporalExtentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -104,11 +113,12 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a class_of_spatio_temporal_extent may be a member of
-         * one or more {@link ClassOfClassOfSpatioTemporalExtent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -118,11 +128,12 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
-         * A relationship type where a member_of a class_of_spatio_temporal_extent is part_of a
-         * member_of some class_of_spatio_temporal_extent.
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -132,9 +143,12 @@ public class ClassOfSpatioTemporalExtentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfSpatioTemporalExtent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSpatioTemporalExtent.
+         * @throws HqdmException If the ClassOfSpatioTemporalExtent is missing any mandatory
+         *         properties.
          */
         public ClassOfSpatioTemporalExtent build() throws HqdmException {
             if (classOfSpatioTemporalExtentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
     /**
+     * Constructs a new ClassOfState.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfState.
      */
     public ClassOfStateImpl(final IRI iri) {
         super(ClassOfStateImpl.class, iri, CLASS_OF_STATE);
     }
 
     /**
-     * Builder for ClassOfStateImpl.
+     * Builder for constructing instances of ClassOfState.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateImpl classOfStateImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfState.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfState.
          */
         public Builder(final IRI iri) {
             classOfStateImpl = new ClassOfStateImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ClassOfStateImpl extends HqdmObject implements ClassOfState {
         }
 
         /**
+         * Returns an instance of ClassOfState created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfState.
+         * @throws HqdmException If the ClassOfState is missing any mandatory properties.
          */
         public ClassOfState build() throws HqdmException {
             if (classOfStateImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfActivityImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfStateOfActivity {
     /**
+     * Constructs a new ClassOfStateOfActivity.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfActivity.
      */
     public ClassOfStateOfActivityImpl(final IRI iri) {
         super(ClassOfStateOfActivityImpl.class, iri, CLASS_OF_STATE_OF_ACTIVITY);
     }
 
     /**
-     * Builder for ClassOfStateOfActivityImpl.
+     * Builder for constructing instances of ClassOfStateOfActivity.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfActivityImpl classOfStateOfActivityImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfActivity.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfActivity.
          */
         public Builder(final IRI iri) {
             classOfStateOfActivityImpl = new ClassOfStateOfActivityImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfActivityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfActivityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfActivityImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * Returns an instance of ClassOfStateOfActivity created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfActivity.
+         * @throws HqdmException If the ClassOfStateOfActivity is missing any mandatory properties.
          */
         public ClassOfStateOfActivity build() throws HqdmException {
             if (classOfStateOfActivityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfAmountOfMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfAmountOfMoneyImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         implements ClassOfStateOfAmountOfMoney {
     /**
+     * Constructs a new ClassOfStateOfAmountOfMoney.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfAmountOfMoney.
      */
     public ClassOfStateOfAmountOfMoneyImpl(final IRI iri) {
         super(ClassOfStateOfAmountOfMoneyImpl.class, iri, CLASS_OF_STATE_OF_AMOUNT_OF_MONEY);
     }
 
     /**
-     * Builder for ClassOfStateOfAmountOfMoneyImpl.
+     * Builder for constructing instances of ClassOfStateOfAmountOfMoney.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfAmountOfMoneyImpl classOfStateOfAmountOfMoneyImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfAmountOfMoney.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfAmountOfMoney.
          */
         public Builder(final IRI iri) {
             classOfStateOfAmountOfMoneyImpl = new ClassOfStateOfAmountOfMoneyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfAmountOfMoneyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfAmountOfMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfAmountOfMoneyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfAmountOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfAmountOfMoney created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfAmountOfMoney.
+         * @throws HqdmException If the ClassOfStateOfAmountOfMoney is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfAmountOfMoney build() throws HqdmException {
             if (classOfStateOfAmountOfMoneyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfAssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfAssociationImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOfStateOfAssociation {
     /**
+     * Constructs a new ClassOfStateOfAssociation.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfAssociation.
      */
     public ClassOfStateOfAssociationImpl(final IRI iri) {
         super(ClassOfStateOfAssociationImpl.class, iri, CLASS_OF_STATE_OF_ASSOCIATION);
     }
 
     /**
-     * Builder for ClassOfStateOfAssociationImpl.
+     * Builder for constructing instances of ClassOfStateOfAssociation.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfAssociationImpl classOfStateOfAssociationImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfAssociation.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfAssociation.
          */
         public Builder(final IRI iri) {
             classOfStateOfAssociationImpl = new ClassOfStateOfAssociationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfAssociationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfAssociationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfAssociationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,12 @@ public class ClassOfStateOfAssociationImpl extends HqdmObject implements ClassOf
         }
 
         /**
+         * Returns an instance of ClassOfStateOfAssociation created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfAssociation.
+         * @throws HqdmException If the ClassOfStateOfAssociation is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfAssociation build() throws HqdmException {
             if (classOfStateOfAssociationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         implements ClassOfStateOfBiologicalObject {
     /**
+     * Constructs a new ClassOfStateOfBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfBiologicalObject.
      */
     public ClassOfStateOfBiologicalObjectImpl(final IRI iri) {
         super(ClassOfStateOfBiologicalObjectImpl.class, iri, CLASS_OF_STATE_OF_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfStateOfBiologicalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfBiologicalObjectImpl classOfStateOfBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfBiologicalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfBiologicalObjectImpl = new ClassOfStateOfBiologicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfBiologicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfBiologicalObject.
+         * @throws HqdmException If the ClassOfStateOfBiologicalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfBiologicalObject build() throws HqdmException {
             if (classOfStateOfBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalSystemComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         implements ClassOfStateOfBiologicalSystemComponent {
     /**
+     * Constructs a new ClassOfStateOfBiologicalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfBiologicalSystemComponent.
      */
     public ClassOfStateOfBiologicalSystemComponentImpl(final IRI iri) {
         super(ClassOfStateOfBiologicalSystemComponentImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfBiologicalSystemComponentImpl.
+     * Builder for constructing instances of ClassOfStateOfBiologicalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfBiologicalSystemComponentImpl classOfStateOfBiologicalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfBiologicalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfBiologicalSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfStateOfBiologicalSystemComponentImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfBiologicalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfBiologicalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfBiologicalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfBiologicalSystemComponent created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfBiologicalSystemComponent.
+         * @throws HqdmException If the ClassOfStateOfBiologicalSystemComponent is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfBiologicalSystemComponent build() throws HqdmException {
             if (classOfStateOfBiologicalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfBiologicalSystemImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         implements ClassOfStateOfBiologicalSystem {
     /**
+     * Constructs a new ClassOfStateOfBiologicalSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfBiologicalSystem.
      */
     public ClassOfStateOfBiologicalSystemImpl(final IRI iri) {
         super(ClassOfStateOfBiologicalSystemImpl.class, iri, CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfStateOfBiologicalSystemImpl.
+     * Builder for constructing instances of ClassOfStateOfBiologicalSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfBiologicalSystemImpl classOfStateOfBiologicalSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfBiologicalSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfBiologicalSystem.
          */
         public Builder(final IRI iri) {
             classOfStateOfBiologicalSystemImpl = new ClassOfStateOfBiologicalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfBiologicalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfBiologicalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfBiologicalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfBiologicalSystemImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfBiologicalSystem created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfBiologicalSystem.
+         * @throws HqdmException If the ClassOfStateOfBiologicalSystem is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfBiologicalSystem build() throws HqdmException {
             if (classOfStateOfBiologicalSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         implements ClassOfStateOfFunctionalObject {
     /**
+     * Constructs a new ClassOfStateOfFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfFunctionalObject.
      */
     public ClassOfStateOfFunctionalObjectImpl(final IRI iri) {
         super(ClassOfStateOfFunctionalObjectImpl.class, iri, CLASS_OF_STATE_OF_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfStateOfFunctionalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfFunctionalObjectImpl classOfStateOfFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfFunctionalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfFunctionalObjectImpl = new ClassOfStateOfFunctionalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfFunctionalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfFunctionalObject.
+         * @throws HqdmException If the ClassOfStateOfFunctionalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfFunctionalObject build() throws HqdmException {
             if (classOfStateOfFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalSystemComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         implements ClassOfStateOfFunctionalSystemComponent {
     /**
+     * Constructs a new ClassOfStateOfFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfFunctionalSystemComponent.
      */
     public ClassOfStateOfFunctionalSystemComponentImpl(final IRI iri) {
         super(ClassOfStateOfFunctionalSystemComponentImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfFunctionalSystemComponentImpl.
+     * Builder for constructing instances of ClassOfStateOfFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfFunctionalSystemComponentImpl classOfStateOfFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfStateOfFunctionalSystemComponentImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfFunctionalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfFunctionalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfFunctionalSystemComponent created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfFunctionalSystemComponent.
+         * @throws HqdmException If the ClassOfStateOfFunctionalSystemComponent is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfFunctionalSystemComponent build() throws HqdmException {
             if (classOfStateOfFunctionalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfFunctionalSystemImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         implements ClassOfStateOfFunctionalSystem {
     /**
+     * Constructs a new ClassOfStateOfFunctionalSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfFunctionalSystem.
      */
     public ClassOfStateOfFunctionalSystemImpl(final IRI iri) {
         super(ClassOfStateOfFunctionalSystemImpl.class, iri, CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfStateOfFunctionalSystemImpl.
+     * Builder for constructing instances of ClassOfStateOfFunctionalSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfFunctionalSystemImpl classOfStateOfFunctionalSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfFunctionalSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfFunctionalSystem.
          */
         public Builder(final IRI iri) {
             classOfStateOfFunctionalSystemImpl = new ClassOfStateOfFunctionalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfFunctionalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfFunctionalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfFunctionalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfFunctionalSystemImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfFunctionalSystem created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfFunctionalSystem.
+         * @throws HqdmException If the ClassOfStateOfFunctionalSystem is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfFunctionalSystem build() throws HqdmException {
             if (classOfStateOfFunctionalSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfIntentionallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfIntentionallyConstructedObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         implements ClassOfStateOfIntentionallyConstructedObject {
     /**
+     * Constructs a new ClassOfStateOfIntentionallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfIntentionallyConstructedObject.
      */
     public ClassOfStateOfIntentionallyConstructedObjectImpl(final IRI iri) {
         super(ClassOfStateOfIntentionallyConstructedObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfIntentionallyConstructedObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfIntentionallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfIntentionallyConstructedObjectImpl classOfStateOfIntentionallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfIntentionallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfIntentionallyConstructedObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfIntentionallyConstructedObjectImpl =
@@ -64,9 +66,13 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -76,9 +82,11 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfIntentionallyConstructedObjectImpl.addValue(HAS_SUPERCLASS,
@@ -87,9 +95,11 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfIntentionallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -97,9 +107,11 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfIntentionallyConstructedObjectImpl.addValue(MEMBER_OF,
@@ -108,9 +120,12 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -120,9 +135,12 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -132,9 +150,12 @@ public class ClassOfStateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfIntentionallyConstructedObject created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfIntentionallyConstructedObject.
+         * @throws HqdmException If the ClassOfStateOfIntentionallyConstructedObject is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfIntentionallyConstructedObject build() throws HqdmException {
             if (classOfStateOfIntentionallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryBiologicalObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         implements ClassOfStateOfOrdinaryBiologicalObject {
     /**
+     * Constructs a new ClassOfStateOfOrdinaryBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfOrdinaryBiologicalObject.
      */
     public ClassOfStateOfOrdinaryBiologicalObjectImpl(final IRI iri) {
         super(ClassOfStateOfOrdinaryBiologicalObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfOrdinaryBiologicalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfOrdinaryBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfOrdinaryBiologicalObjectImpl classOfStateOfOrdinaryBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfOrdinaryBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfOrdinaryBiologicalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfOrdinaryBiologicalObjectImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfOrdinaryBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfOrdinaryBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfOrdinaryBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfOrdinaryBiologicalObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfOrdinaryBiologicalObject.
+         * @throws HqdmException If the ClassOfStateOfOrdinaryBiologicalObject is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfOrdinaryBiologicalObject build() throws HqdmException {
             if (classOfStateOfOrdinaryBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryFunctionalObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         implements ClassOfStateOfOrdinaryFunctionalObject {
     /**
+     * Constructs a new ClassOfStateOfOrdinaryFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfOrdinaryFunctionalObject.
      */
     public ClassOfStateOfOrdinaryFunctionalObjectImpl(final IRI iri) {
         super(ClassOfStateOfOrdinaryFunctionalObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfOrdinaryFunctionalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfOrdinaryFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfOrdinaryFunctionalObjectImpl classOfStateOfOrdinaryFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfOrdinaryFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfOrdinaryFunctionalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfOrdinaryFunctionalObjectImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfOrdinaryFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfOrdinaryFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfOrdinaryFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfOrdinaryFunctionalObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfOrdinaryFunctionalObject.
+         * @throws HqdmException If the ClassOfStateOfOrdinaryFunctionalObject is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfOrdinaryFunctionalObject build() throws HqdmException {
             if (classOfStateOfOrdinaryFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrdinaryPhysicalObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         implements ClassOfStateOfOrdinaryPhysicalObject {
     /**
+     * Constructs a new ClassOfStateOfOrdinaryPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfOrdinaryPhysicalObject.
      */
     public ClassOfStateOfOrdinaryPhysicalObjectImpl(final IRI iri) {
         super(ClassOfStateOfOrdinaryPhysicalObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfOrdinaryPhysicalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfOrdinaryPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfOrdinaryPhysicalObjectImpl classOfStateOfOrdinaryPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfOrdinaryPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfOrdinaryPhysicalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfOrdinaryPhysicalObjectImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfOrdinaryPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfOrdinaryPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfOrdinaryPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfOrdinaryPhysicalObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfOrdinaryPhysicalObject.
+         * @throws HqdmException If the ClassOfStateOfOrdinaryPhysicalObject is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfOrdinaryPhysicalObject build() throws HqdmException {
             if (classOfStateOfOrdinaryPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrganizationComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrganizationComponentImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         implements ClassOfStateOfOrganizationComponent {
     /**
+     * Constructs a new ClassOfStateOfOrganizationComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfOrganizationComponent.
      */
     public ClassOfStateOfOrganizationComponentImpl(final IRI iri) {
         super(ClassOfStateOfOrganizationComponentImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfOrganizationComponentImpl.
+     * Builder for constructing instances of ClassOfStateOfOrganizationComponent.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfOrganizationComponentImpl classOfStateOfOrganizationComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfOrganizationComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfOrganizationComponent.
          */
         public Builder(final IRI iri) {
             classOfStateOfOrganizationComponentImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfOrganizationComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfOrganizationComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfOrganizationComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfOrganizationComponent created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfOrganizationComponent.
+         * @throws HqdmException If the ClassOfStateOfOrganizationComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfOrganizationComponent build() throws HqdmException {
             if (classOfStateOfOrganizationComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrganizationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfOrganizationImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfOrganizationImpl extends HqdmObject
         implements ClassOfStateOfOrganization {
     /**
+     * Constructs a new ClassOfStateOfOrganization.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfOrganization.
      */
     public ClassOfStateOfOrganizationImpl(final IRI iri) {
         super(ClassOfStateOfOrganizationImpl.class, iri, CLASS_OF_STATE_OF_ORGANIZATION);
     }
 
     /**
-     * Builder for ClassOfStateOfOrganizationImpl.
+     * Builder for constructing instances of ClassOfStateOfOrganization.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfOrganizationImpl classOfStateOfOrganizationImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfOrganization.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfOrganization.
          */
         public Builder(final IRI iri) {
             classOfStateOfOrganizationImpl = new ClassOfStateOfOrganizationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfOrganizationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfOrganizationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfOrganizationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfOrganizationImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfOrganization created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfOrganization.
+         * @throws HqdmException If the ClassOfStateOfOrganization is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfOrganization build() throws HqdmException {
             if (classOfStateOfOrganizationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPartyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPartyImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateOfParty {
     /**
+     * Constructs a new ClassOfStateOfParty.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfParty.
      */
     public ClassOfStateOfPartyImpl(final IRI iri) {
         super(ClassOfStateOfPartyImpl.class, iri, CLASS_OF_STATE_OF_PARTY);
     }
 
     /**
-     * Builder for ClassOfStateOfPartyImpl.
+     * Builder for constructing instances of ClassOfStateOfParty.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfPartyImpl classOfStateOfPartyImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfParty.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfParty.
          */
         public Builder(final IRI iri) {
             classOfStateOfPartyImpl = new ClassOfStateOfPartyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfPartyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfPartyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfPartyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfPartyImpl extends HqdmObject implements ClassOfStateO
         }
 
         /**
+         * Returns an instance of ClassOfStateOfParty created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfParty.
+         * @throws HqdmException If the ClassOfStateOfParty is missing any mandatory properties.
          */
         public ClassOfStateOfParty build() throws HqdmException {
             if (classOfStateOfPartyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPersonImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPersonImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfStateOfPerson {
     /**
+     * Constructs a new ClassOfStateOfPerson.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfPerson.
      */
     public ClassOfStateOfPersonImpl(final IRI iri) {
         super(ClassOfStateOfPersonImpl.class, iri, CLASS_OF_STATE_OF_PERSON);
     }
 
     /**
-     * Builder for ClassOfStateOfPersonImpl.
+     * Builder for constructing instances of ClassOfStateOfPerson.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfPersonImpl classOfStateOfPersonImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfPerson.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfPerson.
          */
         public Builder(final IRI iri) {
             classOfStateOfPersonImpl = new ClassOfStateOfPersonImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfPersonImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfPersonImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfPersonImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfPersonImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * Returns an instance of ClassOfStateOfPerson created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfPerson.
+         * @throws HqdmException If the ClassOfStateOfPerson is missing any mandatory properties.
          */
         public ClassOfStateOfPerson build() throws HqdmException {
             if (classOfStateOfPersonImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPhysicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         implements ClassOfStateOfPhysicalObject {
     /**
+     * Constructs a new ClassOfStateOfPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfPhysicalObject.
      */
     public ClassOfStateOfPhysicalObjectImpl(final IRI iri) {
         super(ClassOfStateOfPhysicalObjectImpl.class, iri, CLASS_OF_STATE_OF_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for ClassOfStateOfPhysicalObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfPhysicalObjectImpl classOfStateOfPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfPhysicalObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfPhysicalObjectImpl = new ClassOfStateOfPhysicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfPhysicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfPhysicalObject.
+         * @throws HqdmException If the ClassOfStateOfPhysicalObject is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfPhysicalObject build() throws HqdmException {
             if (classOfStateOfPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfPositionImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfStateOfPosition {
     /**
+     * Constructs a new ClassOfStateOfPosition.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfPosition.
      */
     public ClassOfStateOfPositionImpl(final IRI iri) {
         super(ClassOfStateOfPositionImpl.class, iri, CLASS_OF_STATE_OF_POSITION);
     }
 
     /**
-     * Builder for ClassOfStateOfPositionImpl.
+     * Builder for constructing instances of ClassOfStateOfPosition.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfPositionImpl classOfStateOfPositionImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfPosition.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfPosition.
          */
         public Builder(final IRI iri) {
             classOfStateOfPositionImpl = new ClassOfStateOfPositionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfPositionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfPositionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfPositionImpl extends HqdmObject implements ClassOfSta
         }
 
         /**
+         * Returns an instance of ClassOfStateOfPosition created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfPosition.
+         * @throws HqdmException If the ClassOfStateOfPosition is missing any mandatory properties.
          */
         public ClassOfStateOfPosition build() throws HqdmException {
             if (classOfStateOfPositionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSalesProductInstanceImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSalesProductInstanceImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         implements ClassOfStateOfSalesProductInstance {
     /**
+     * Constructs a new ClassOfStateOfSalesProductInstance.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSalesProductInstance.
      */
     public ClassOfStateOfSalesProductInstanceImpl(final IRI iri) {
         super(ClassOfStateOfSalesProductInstanceImpl.class, iri,
@@ -46,15 +47,16 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfSalesProductInstanceImpl.
+     * Builder for constructing instances of ClassOfStateOfSalesProductInstance.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfSalesProductInstanceImpl classOfStateOfSalesProductInstanceImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSalesProductInstance.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSalesProductInstance.
          */
         public Builder(final IRI iri) {
             classOfStateOfSalesProductInstanceImpl =
@@ -62,9 +64,13 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSalesProductInstanceImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +92,11 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSalesProductInstanceImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -94,9 +104,11 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSalesProductInstanceImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -104,9 +116,12 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -116,9 +131,12 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -128,9 +146,12 @@ public class ClassOfStateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSalesProductInstance created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSalesProductInstance.
+         * @throws HqdmException If the ClassOfStateOfSalesProductInstance is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfSalesProductInstance build() throws HqdmException {
             if (classOfStateOfSalesProductInstanceImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSignImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSignImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOfSign {
     /**
+     * Constructs a new ClassOfStateOfSign.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSign.
      */
     public ClassOfStateOfSignImpl(final IRI iri) {
         super(ClassOfStateOfSignImpl.class, iri, CLASS_OF_STATE_OF_SIGN);
     }
 
     /**
-     * Builder for ClassOfStateOfSignImpl.
+     * Builder for constructing instances of ClassOfStateOfSign.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfSignImpl classOfStateOfSignImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSign.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSign.
          */
         public Builder(final IRI iri) {
             classOfStateOfSignImpl = new ClassOfStateOfSignImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSignImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSignImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSignImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfSignImpl extends HqdmObject implements ClassOfStateOf
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSign created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSign.
+         * @throws HqdmException If the ClassOfStateOfSign is missing any mandatory properties.
          */
         public ClassOfStateOfSign build() throws HqdmException {
             if (classOfStateOfSignImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSociallyConstructedActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSociallyConstructedActivityImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         implements ClassOfStateOfSociallyConstructedActivity {
     /**
+     * Constructs a new ClassOfStateOfSociallyConstructedActivity.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSociallyConstructedActivity.
      */
     public ClassOfStateOfSociallyConstructedActivityImpl(final IRI iri) {
         super(ClassOfStateOfSociallyConstructedActivityImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfSociallyConstructedActivityImpl.
+     * Builder for constructing instances of ClassOfStateOfSociallyConstructedActivity.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfSociallyConstructedActivityImpl classOfStateOfSociallyConstructedActivityImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSociallyConstructedActivity.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSociallyConstructedActivity.
          */
         public Builder(final IRI iri) {
             classOfStateOfSociallyConstructedActivityImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSociallyConstructedActivityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSociallyConstructedActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSociallyConstructedActivityImpl.addValue(MEMBER_OF,
@@ -106,9 +118,12 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -118,9 +133,12 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -130,9 +148,12 @@ public class ClassOfStateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSociallyConstructedActivity created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSociallyConstructedActivity.
+         * @throws HqdmException If the ClassOfStateOfSociallyConstructedActivity is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfSociallyConstructedActivity build() throws HqdmException {
             if (classOfStateOfSociallyConstructedActivityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSociallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSociallyConstructedObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         implements ClassOfStateOfSociallyConstructedObject {
     /**
+     * Constructs a new ClassOfStateOfSociallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSociallyConstructedObject.
      */
     public ClassOfStateOfSociallyConstructedObjectImpl(final IRI iri) {
         super(ClassOfStateOfSociallyConstructedObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for ClassOfStateOfSociallyConstructedObjectImpl.
+     * Builder for constructing instances of ClassOfStateOfSociallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final ClassOfStateOfSociallyConstructedObjectImpl classOfStateOfSociallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSociallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSociallyConstructedObject.
          */
         public Builder(final IRI iri) {
             classOfStateOfSociallyConstructedObjectImpl =
@@ -63,9 +65,13 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSociallyConstructedObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSociallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSociallyConstructedObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class ClassOfStateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSociallyConstructedObject created from the
+         * properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSociallyConstructedObject.
+         * @throws HqdmException If the ClassOfStateOfSociallyConstructedObject is missing any
+         *         mandatory properties.
          */
         public ClassOfStateOfSociallyConstructedObject build() throws HqdmException {
             if (classOfStateOfSociallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSystemComponentImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         implements ClassOfStateOfSystemComponent {
     /**
+     * Constructs a new ClassOfStateOfSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSystemComponent.
      */
     public ClassOfStateOfSystemComponentImpl(final IRI iri) {
         super(ClassOfStateOfSystemComponentImpl.class, iri, CLASS_OF_STATE_OF_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for ClassOfStateOfSystemComponentImpl.
+     * Builder for constructing instances of ClassOfStateOfSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfSystemComponentImpl classOfStateOfSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfStateOfSystemComponentImpl = new ClassOfStateOfSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class ClassOfStateOfSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSystemComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSystemComponent.
+         * @throws HqdmException If the ClassOfStateOfSystemComponent is missing any mandatory
+         *         properties.
          */
         public ClassOfStateOfSystemComponent build() throws HqdmException {
             if (classOfStateOfSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfStateOfSystemImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfStateOfSystem {
     /**
+     * Constructs a new ClassOfStateOfSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfStateOfSystem.
      */
     public ClassOfStateOfSystemImpl(final IRI iri) {
         super(ClassOfStateOfSystemImpl.class, iri, CLASS_OF_STATE_OF_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfStateOfSystemImpl.
+     * Builder for constructing instances of ClassOfStateOfSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfStateOfSystemImpl classOfStateOfSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfStateOfSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfStateOfSystem.
          */
         public Builder(final IRI iri) {
             classOfStateOfSystemImpl = new ClassOfStateOfSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfStateOfSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfStateOfSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfStateOfSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfStateOfSystemImpl extends HqdmObject implements ClassOfState
         }
 
         /**
+         * Returns an instance of ClassOfStateOfSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfStateOfSystem.
+         * @throws HqdmException If the ClassOfStateOfSystem is missing any mandatory properties.
          */
         public ClassOfStateOfSystem build() throws HqdmException {
             if (classOfStateOfSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSystemComponentImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSystemComponent {
     /**
+     * Constructs a new ClassOfSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSystemComponent.
      */
     public ClassOfSystemComponentImpl(final IRI iri) {
         super(ClassOfSystemComponentImpl.class, iri, CLASS_OF_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for ClassOfSystemComponentImpl.
+     * Builder for constructing instances of ClassOfSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSystemComponentImpl classOfSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSystemComponent.
          */
         public Builder(final IRI iri) {
             classOfSystemComponentImpl = new ClassOfSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class ClassOfSystemComponentImpl extends HqdmObject implements ClassOfSys
         }
 
         /**
+         * Returns an instance of ClassOfSystemComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSystemComponent.
+         * @throws HqdmException If the ClassOfSystemComponent is missing any mandatory properties.
          */
         public ClassOfSystemComponent build() throws HqdmException {
             if (classOfSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassOfSystemImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
     /**
+     * Constructs a new ClassOfSystem.
      *
-     * @param iri
+     * @param iri IRI of the ClassOfSystem.
      */
     public ClassOfSystemImpl(final IRI iri) {
         super(ClassOfSystemImpl.class, iri, CLASS_OF_SYSTEM);
     }
 
     /**
-     * Builder for ClassOfSystemImpl.
+     * Builder for constructing instances of ClassOfSystem.
      */
     public static class Builder {
-        /** */
+
         private final ClassOfSystemImpl classOfSystemImpl;
 
         /**
+         * Constructs a Builder for a new ClassOfSystem.
          *
-         * @param iri
+         * @param iri IRI of the ClassOfSystem.
          */
         public Builder(final IRI iri) {
             classOfSystemImpl = new ClassOfSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             classOfSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classOfSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             classOfSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ClassOfSystemImpl extends HqdmObject implements ClassOfSystem {
         }
 
         /**
+         * Returns an instance of ClassOfSystem created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ClassOfSystem.
+         * @throws HqdmException If the ClassOfSystem is missing any mandatory properties.
          */
         public ClassOfSystem build() throws HqdmException {
             if (classOfSystemImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassificationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ClassificationImpl.java
@@ -33,33 +33,35 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ClassificationImpl extends HqdmObject implements Classification {
     /**
+     * Constructs a new Classification.
      *
-     * @param iri
+     * @param iri IRI of the Classification.
      */
     public ClassificationImpl(final IRI iri) {
         super(ClassificationImpl.class, iri, CLASSIFICATION);
     }
 
     /**
-     * Builder for ClassificationImpl.
+     * Builder for constructing instances of Classification.
      */
     public static class Builder {
-        /** */
+
         private final ClassificationImpl classificationImpl;
 
         /**
+         * Constructs a Builder for a new Classification.
          *
-         * @param iri
+         * @param iri IRI of the Classification.
          */
         public Builder(final IRI iri) {
             classificationImpl = new ClassificationImpl(iri);
         }
 
         /**
-         * A relationship type where a classification has exactly one classifier.
+         * A relationship type where a {@link Classification} has exactly one classifier.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder classifier_M(final Class clazz) {
             classificationImpl.addValue(CLASSIFIER, clazz.getIri());
@@ -67,10 +69,10 @@ public class ClassificationImpl extends HqdmObject implements Classification {
         }
 
         /**
-         * A relationship type where a classification has exactly one member.
+         * A relationship type where a {@link Classification} has exactly one member.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder member_M(final Thing thing) {
             classificationImpl.addValue(MEMBER, thing.getIri());
@@ -78,9 +80,15 @@ public class ClassificationImpl extends HqdmObject implements Classification {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * <p>
+         * Note: This relationship is the same as the entity type {@link Classification}.
+         * </p>
+         * clazz.
+         *
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             classificationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -88,9 +96,11 @@ public class ClassificationImpl extends HqdmObject implements Classification {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             classificationImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -98,9 +108,10 @@ public class ClassificationImpl extends HqdmObject implements Classification {
         }
 
         /**
+         * Returns an instance of Classification created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Classification.
+         * @throws HqdmException If the Classification is missing any mandatory properties.
          */
         public Classification build() throws HqdmException {
             if (!classificationImpl.hasValue(CLASSIFIER)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/CompositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/CompositionImpl.java
@@ -33,32 +33,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class CompositionImpl extends HqdmObject implements Composition {
     /**
+     * Constructs a new Composition.
      *
-     * @param iri
+     * @param iri IRI of the Composition.
      */
     public CompositionImpl(final IRI iri) {
         super(CompositionImpl.class, iri, COMPOSITION);
     }
 
     /**
-     * Builder for CompositionImpl.
+     * Builder for constructing instances of Composition.
      */
     public static class Builder {
-        /** */
+
         private final CompositionImpl compositionImpl;
 
         /**
+         * Constructs a Builder for a new Composition.
          *
-         * @param iri
+         * @param iri IRI of the Composition.
          */
         public Builder(final IRI iri) {
             compositionImpl = new CompositionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             compositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -66,9 +70,11 @@ public class CompositionImpl extends HqdmObject implements Composition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             compositionImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -76,9 +82,11 @@ public class CompositionImpl extends HqdmObject implements Composition {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the part.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part_M(final SpatioTemporalExtent spatioTemporalExtent) {
             compositionImpl.addValue(PART, spatioTemporalExtent.getIri());
@@ -86,9 +94,11 @@ public class CompositionImpl extends HqdmObject implements Composition {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the whole.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder whole_M(final SpatioTemporalExtent spatioTemporalExtent) {
             compositionImpl.addValue(WHOLE, spatioTemporalExtent.getIri());
@@ -96,9 +106,10 @@ public class CompositionImpl extends HqdmObject implements Composition {
         }
 
         /**
+         * Returns an instance of Composition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Composition.
+         * @throws HqdmException If the Composition is missing any mandatory properties.
          */
         public Composition build() throws HqdmException {
             if (compositionImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ContractExecutionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ContractExecutionImpl.java
@@ -56,32 +56,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ContractExecutionImpl extends HqdmObject implements ContractExecution {
     /**
+     * Constructs a new ContractExecution.
      *
-     * @param iri
+     * @param iri IRI of the ContractExecution.
      */
     public ContractExecutionImpl(final IRI iri) {
         super(ContractExecutionImpl.class, iri, CONTRACT_EXECUTION);
     }
 
     /**
-     * Builder for ContractExecutionImpl.
+     * Builder for constructing instances of ContractExecution.
      */
     public static class Builder {
-        /** */
+
         private final ContractExecutionImpl contractExecutionImpl;
 
         /**
+         * Constructs a Builder for a new ContractExecution.
          *
-         * @param iri
+         * @param iri IRI of the ContractExecution.
          */
         public Builder(final IRI iri) {
             contractExecutionImpl = new ContractExecutionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             contractExecutionImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -89,9 +97,11 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             contractExecutionImpl.addValue(BEGINNING, event.getIri());
@@ -99,9 +109,11 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             contractExecutionImpl.addValue(CAUSES, event.getIri());
@@ -109,9 +121,15 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractExecutionImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -119,9 +137,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             contractExecutionImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -129,9 +150,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             contractExecutionImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -139,9 +163,11 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             contractExecutionImpl.addValue(DETERMINES, thing.getIri());
@@ -149,9 +175,11 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             contractExecutionImpl.addValue(ENDING, event.getIri());
@@ -159,9 +187,10 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             contractExecutionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -169,11 +198,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
-         * A member_of relationship type where a contract_execution may be a member_of one or more
-         * {@link ClassOfContractExecution}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ContractExecution} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
+         * more {@link ClassOfContractExecution}.
          *
-         * @param classOfContractExecution
-         * @return
+         * @param classOfContractExecution The ClassOfContractExecution.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfContractExecution classOfContractExecution) {
             contractExecutionImpl.addValue(MEMBER_OF, classOfContractExecution.getIri());
@@ -181,9 +211,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             contractExecutionImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -191,9 +224,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractExecutionImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -201,11 +237,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
-         * A part_of relationship type where a contract_execution is part_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link ContractExecution} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly one
          * {@link ContractProcess}.
          *
-         * @param contractProcess
-         * @return
+         * @param contractProcess The ContractProcess.
+         * @return This builder.
          */
         public final Builder part_Of_M(final ContractProcess contractProcess) {
             contractExecutionImpl.addValue(PART_OF, contractProcess.getIri());
@@ -213,9 +250,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             contractExecutionImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -223,9 +263,17 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             contractExecutionImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -233,9 +281,10 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             contractExecutionImpl.addValue(REFERENCES, thing.getIri());
@@ -243,9 +292,12 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractExecutionImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -253,9 +305,21 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             contractExecutionImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -263,9 +327,10 @@ public class ContractExecutionImpl extends HqdmObject implements ContractExecuti
         }
 
         /**
+         * Returns an instance of ContractExecution created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ContractExecution.
+         * @throws HqdmException If the ContractExecution is missing any mandatory properties.
          */
         public ContractExecution build() throws HqdmException {
             if (contractExecutionImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ContractProcessImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ContractProcessImpl.java
@@ -58,32 +58,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ContractProcessImpl extends HqdmObject implements ContractProcess {
     /**
+     * Constructs a new ContractProcess.
      *
-     * @param iri
+     * @param iri IRI of the ContractProcess.
      */
     public ContractProcessImpl(final IRI iri) {
         super(ContractProcessImpl.class, iri, CONTRACT_PROCESS);
     }
 
     /**
-     * Builder for ContractProcessImpl.
+     * Builder for constructing instances of ContractProcess.
      */
     public static class Builder {
-        /** */
+
         private final ContractProcessImpl contractProcessImpl;
 
         /**
+         * Constructs a Builder for a new ContractProcess.
          *
-         * @param iri
+         * @param iri IRI of the ContractProcess.
          */
         public Builder(final IRI iri) {
             contractProcessImpl = new ContractProcessImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             contractProcessImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -91,9 +99,11 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             contractProcessImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +111,11 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             contractProcessImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +123,15 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractProcessImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,11 +139,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
-         * A consists_of relationship type where a contract_process consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where a
+         * {@link ContractProcess} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link AgreeContract}.
          *
-         * @param agreeContract
-         * @return
+         * @param agreeContract The AgreeContract.
+         * @return This builder.
          */
         public final Builder consists_Of(final AgreeContract agreeContract) {
             contractProcessImpl.addValue(CONSISTS_OF, agreeContract.getIri());
@@ -133,11 +152,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
-         * A consists_of_ relationship type where a contract_process consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_} relationship type where a
+         * {@link ContractProcess} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link ContractExecution}.
          *
-         * @param contractExecution
-         * @return
+         * @param contractExecution The ContractExecution.
+         * @return This builder.
          */
         public final Builder consists_Of_(final ContractExecution contractExecution) {
             contractProcessImpl.addValue(CONSISTS_OF_, contractExecution.getIri());
@@ -145,9 +165,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             contractProcessImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -155,9 +178,11 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             contractProcessImpl.addValue(DETERMINES, thing.getIri());
@@ -165,9 +190,11 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             contractProcessImpl.addValue(ENDING, event.getIri());
@@ -175,9 +202,10 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             contractProcessImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -185,11 +213,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
-         * A member_of relationship type where a contract process may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a contract process
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfContractProcess}.
          *
-         * @param classOfContractProcess
-         * @return
+         * @param classOfContractProcess The ClassOfContractProcess.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfContractProcess classOfContractProcess) {
             contractProcessImpl.addValue(MEMBER_OF, classOfContractProcess.getIri());
@@ -197,9 +226,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             contractProcessImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -207,9 +239,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractProcessImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -217,9 +252,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link ReachingAgreement}.
          *
-         * @param reachingAgreement
-         * @return
+         * @param reachingAgreement The ReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of(final ReachingAgreement reachingAgreement) {
             contractProcessImpl.addValue(PART_OF, reachingAgreement.getIri());
@@ -227,9 +265,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             contractProcessImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -237,9 +278,17 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             contractProcessImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -247,9 +296,11 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             contractProcessImpl.addValue(REFERENCES, thing.getIri());
@@ -257,9 +308,12 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             contractProcessImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -267,9 +321,21 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             contractProcessImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -277,9 +343,10 @@ public class ContractProcessImpl extends HqdmObject implements ContractProcess {
         }
 
         /**
+         * Returns an instance of ContractProcess created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ContractProcess.
+         * @throws HqdmException If the ContractProcess is missing any mandatory properties.
          */
         public ContractProcess build() throws HqdmException {
             if (contractProcessImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/CurrencyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/CurrencyImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class CurrencyImpl extends HqdmObject implements Currency {
     /**
+     * Constructs a new Currency.
      *
-     * @param iri
+     * @param iri IRI of the Currency.
      */
     public CurrencyImpl(final IRI iri) {
         super(CurrencyImpl.class, iri, CURRENCY);
     }
 
     /**
-     * Builder for CurrencyImpl.
+     * Builder for constructing instances of Currency.
      */
     public static class Builder {
-        /** */
+
         private final CurrencyImpl currencyImpl;
 
         /**
+         * Constructs a Builder for a new Currency.
          *
-         * @param iri
+         * @param iri IRI of the Currency.
          */
         public Builder(final IRI iri) {
             currencyImpl = new CurrencyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             currencyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             currencyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             currencyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class CurrencyImpl extends HqdmObject implements Currency {
         }
 
         /**
+         * Returns an instance of Currency created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Currency.
+         * @throws HqdmException If the Currency is missing any mandatory properties.
          */
         public Currency build() throws HqdmException {
             if (currencyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/DefinedRelationshipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/DefinedRelationshipImpl.java
@@ -34,34 +34,37 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class DefinedRelationshipImpl extends HqdmObject implements DefinedRelationship {
     /**
+     * Constructs a new DefinedRelationship.
      *
-     * @param iri
+     * @param iri IRI of the DefinedRelationship.
      */
     public DefinedRelationshipImpl(final IRI iri) {
         super(DefinedRelationshipImpl.class, iri, DEFINED_RELATIONSHIP);
     }
 
     /**
-     * Builder for DefinedRelationshipImpl.
+     * Builder for constructing instances of DefinedRelationship.
      */
     public static class Builder {
-        /** */
+
         private final DefinedRelationshipImpl definedRelationshipImpl;
 
         /**
+         * Constructs a Builder for a new DefinedRelationship.
          *
-         * @param iri
+         * @param iri IRI of the DefinedRelationship.
          */
         public Builder(final IRI iri) {
             definedRelationshipImpl = new DefinedRelationshipImpl(iri);
         }
 
         /**
-         * A meta-relationship type where the {@link Classification} of some thing in a role is
-         * involved in a relationship.
+         * A meta-relationship type where the {@link Classification} of some
+         * {@link uk.gov.gchq.hqdm.model.Thing} in a role is involved in a
+         * {@link uk.gov.gchq.hqdm.model.Relationship}.
          *
-         * @param classification
-         * @return
+         * @param classification The Classification.
+         * @return This builder.
          */
         public final Builder involves_M(final Classification classification) {
             definedRelationshipImpl.addValue(INVOLVES, classification.getIri());
@@ -69,9 +72,11 @@ public class DefinedRelationshipImpl extends HqdmObject implements DefinedRelati
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             definedRelationshipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -79,9 +84,11 @@ public class DefinedRelationshipImpl extends HqdmObject implements DefinedRelati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             definedRelationshipImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -89,11 +96,12 @@ public class DefinedRelationshipImpl extends HqdmObject implements DefinedRelati
         }
 
         /**
-         * A member_of relationship type where each defined_relationship is a member_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where each
+         * {@link DefinedRelationship} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} exactly one
          * {@link KindOfRelationshipWithSignature}.
          *
-         * @param kindOfRelationshipWithSignature
-         * @return
+         * @param kindOfRelationshipWithSignature The KindOfRelationshipWithSignature.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(
                 final KindOfRelationshipWithSignature kindOfRelationshipWithSignature) {
@@ -103,9 +111,11 @@ public class DefinedRelationshipImpl extends HqdmObject implements DefinedRelati
         }
 
         /**
+         * Returns an instance of DefinedRelationship created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built DefinedRelationship.
+         * @throws HqdmException If the DefinedRelationship is missing any mandatory properties.
          */
         public DefinedRelationship build() throws HqdmException {
             if (!definedRelationshipImpl.hasValue(INVOLVES)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/DefinitionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/DefinitionImpl.java
@@ -32,32 +32,39 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class DefinitionImpl extends HqdmObject implements Definition {
     /**
+     * Constructs a new Definition.
      *
-     * @param iri
+     * @param iri IRI of the Definition.
      */
     public DefinitionImpl(final IRI iri) {
         super(DefinitionImpl.class, iri, DEFINITION);
     }
 
     /**
-     * Builder for DefinitionImpl.
+     * Builder for constructing instances of Definition.
      */
     public static class Builder {
-        /** */
+
         private final DefinitionImpl definitionImpl;
 
         /**
+         * Constructs a Builder for a new Definition.
          *
-         * @param iri
+         * @param iri IRI of the Definition.
          */
         public Builder(final IRI iri) {
             definitionImpl = new DefinitionImpl(iri);
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} has a
+         * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link Pattern}.
          *
-         * @param pattern
-         * @return
+         * @param pattern The Pattern.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class_M(final Pattern pattern) {
             definitionImpl.addValue(CONSISTS_OF_BY_CLASS, pattern.getIri());
@@ -65,9 +72,13 @@ public class DefinitionImpl extends HqdmObject implements Definition {
         }
 
         /**
+         * A relationship type where a {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_In_Members_M(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -76,10 +87,10 @@ public class DefinitionImpl extends HqdmObject implements Definition {
         }
 
         /**
-         * A relationship type where exactly one {@link Class} is defined by the definition.
+         * A relationship type where exactly one {@link Class} is defined by the {@link Definition}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder represented_M(final Class clazz) {
             definitionImpl.addValue(REPRESENTED, clazz.getIri());
@@ -87,9 +98,10 @@ public class DefinitionImpl extends HqdmObject implements Definition {
         }
 
         /**
+         * Returns an instance of Definition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Definition.
+         * @throws HqdmException If the Definition is missing any mandatory properties.
          */
         public Definition build() throws HqdmException {
             if (!definitionImpl.hasValue(CONSISTS_OF_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/DescriptionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/DescriptionImpl.java
@@ -32,32 +32,39 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class DescriptionImpl extends HqdmObject implements Description {
     /**
+     * Constructs a new Description.
      *
-     * @param iri
+     * @param iri IRI of the Description.
      */
     public DescriptionImpl(final IRI iri) {
         super(DescriptionImpl.class, iri, DESCRIPTION);
     }
 
     /**
-     * Builder for DescriptionImpl.
+     * Builder for constructing instances of Description.
      */
     public static class Builder {
-        /** */
+
         private final DescriptionImpl descriptionImpl;
 
         /**
+         * Constructs a Builder for a new Description.
          *
-         * @param iri
+         * @param iri IRI of the Description.
          */
         public Builder(final IRI iri) {
             descriptionImpl = new DescriptionImpl(iri);
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} has a
+         * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link Pattern}.
          *
-         * @param pattern
-         * @return
+         * @param pattern The Pattern.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class_M(final Pattern pattern) {
             descriptionImpl.addValue(CONSISTS_OF_BY_CLASS, pattern.getIri());
@@ -65,9 +72,13 @@ public class DescriptionImpl extends HqdmObject implements Description {
         }
 
         /**
+         * A relationship type where a {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_In_Members_M(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -76,9 +87,12 @@ public class DescriptionImpl extends HqdmObject implements Description {
         }
 
         /**
+         * A relationship type where the {@link Thing} is represented by each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder represented_M(final Thing thing) {
             descriptionImpl.addValue(REPRESENTED, thing.getIri());
@@ -86,9 +100,10 @@ public class DescriptionImpl extends HqdmObject implements Description {
         }
 
         /**
+         * Returns an instance of Description created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Description.
+         * @throws HqdmException If the Description is missing any mandatory properties.
          */
         public Description build() throws HqdmException {
             if (!descriptionImpl.hasValue(CONSISTS_OF_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EmployeeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EmployeeImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EmployeeImpl extends HqdmObject implements Employee {
     /**
+     * Constructs a new Employee.
      *
-     * @param iri
+     * @param iri IRI of the Employee.
      */
     public EmployeeImpl(final IRI iri) {
         super(EmployeeImpl.class, iri, EMPLOYEE);
     }
 
     /**
-     * Builder for EmployeeImpl.
+     * Builder for constructing instances of Employee.
      */
     public static class Builder {
-        /** */
+
         private final EmployeeImpl employeeImpl;
 
         /**
+         * Constructs a Builder for a new Employee.
          *
-         * @param iri
+         * @param iri IRI of the Employee.
          */
         public Builder(final IRI iri) {
             employeeImpl = new EmployeeImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             employeeImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             employeeImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employeeImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             employeeImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             employeeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPerson} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfStateOfPerson}.
          *
-         * @param classOfStateOfPerson
-         * @return
+         * @param classOfStateOfPerson The ClassOfStateOfPerson.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfPerson classOfStateOfPerson) {
             employeeImpl.addValue(MEMBER_OF, classOfStateOfPerson.getIri());
@@ -129,9 +152,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             employeeImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employeeImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             employeeImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
-         * A participant_in relationship type where an employee is a participant_in exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where an
+         * {@link Employee} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} exactly one
          * {@link Employment}.
          *
-         * @param employment
-         * @return
+         * @param employment The Employment.
+         * @return This builder.
          */
         public final Builder participant_In_M(final Employment employment) {
             employeeImpl.addValue(PARTICIPANT_IN, employment.getIri());
@@ -171,9 +209,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employeeImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +222,12 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPerson} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Person}.
          *
-         * @param person
-         * @return
+         * @param person The Person.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Person person) {
             employeeImpl.addValue(TEMPORAL_PART_OF, person.getIri());
@@ -191,9 +235,10 @@ public class EmployeeImpl extends HqdmObject implements Employee {
         }
 
         /**
+         * Returns an instance of Employee created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Employee.
+         * @throws HqdmException If the Employee is missing any mandatory properties.
          */
         public Employee build() throws HqdmException {
             if (employeeImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EmployerImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EmployerImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EmployerImpl extends HqdmObject implements Employer {
     /**
+     * Constructs a new Employer.
      *
-     * @param iri
+     * @param iri IRI of the Employer.
      */
     public EmployerImpl(final IRI iri) {
         super(EmployerImpl.class, iri, EMPLOYER);
     }
 
     /**
-     * Builder for EmployerImpl.
+     * Builder for constructing instances of Employer.
      */
     public static class Builder {
-        /** */
+
         private final EmployerImpl employerImpl;
 
         /**
+         * Constructs a Builder for a new Employer.
          *
-         * @param iri
+         * @param iri IRI of the Employer.
          */
         public Builder(final IRI iri) {
             employerImpl = new EmployerImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             employerImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             employerImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employerImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             employerImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             employerImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfStateOfParty}.
          *
-         * @param classOfStateOfParty
-         * @return
+         * @param classOfStateOfParty The ClassOfStateOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfParty classOfStateOfParty) {
             employerImpl.addValue(MEMBER_OF, classOfStateOfParty.getIri());
@@ -129,9 +152,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             employerImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employerImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             employerImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
-         * A participant_in relationship type where an employer is a participant_in exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where an
+         * {@link Employer} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} exactly one
          * {@link Employment}.
          *
-         * @param employment
-         * @return
+         * @param employment The Employment.
+         * @return This builder.
          */
         public final Builder participant_In_M(final Employment employment) {
             employerImpl.addValue(PARTICIPANT_IN, employment.getIri());
@@ -171,9 +209,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employerImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +222,12 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Party}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Party party) {
             employerImpl.addValue(TEMPORAL_PART_OF, party.getIri());
@@ -191,9 +235,10 @@ public class EmployerImpl extends HqdmObject implements Employer {
         }
 
         /**
+         * Returns an instance of Employer created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Employer.
+         * @throws HqdmException If the Employer is missing any mandatory properties.
          */
         public Employer build() throws HqdmException {
             if (employerImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EmploymentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EmploymentImpl.java
@@ -48,32 +48,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EmploymentImpl extends HqdmObject implements Employment {
     /**
+     * Constructs a new Employment.
      *
-     * @param iri
+     * @param iri IRI of the Employment.
      */
     public EmploymentImpl(final IRI iri) {
         super(EmploymentImpl.class, iri, EMPLOYMENT);
     }
 
     /**
-     * Builder for EmploymentImpl.
+     * Builder for constructing instances of Employment.
      */
     public static class Builder {
-        /** */
+
         private final EmploymentImpl employmentImpl;
 
         /**
+         * Constructs a Builder for a new Employment.
          *
-         * @param iri
+         * @param iri IRI of the Employment.
          */
         public Builder(final IRI iri) {
             employmentImpl = new EmploymentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             employmentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -81,9 +89,11 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             employmentImpl.addValue(BEGINNING, event.getIri());
@@ -91,9 +101,15 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employmentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -101,11 +117,11 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
-         * A consists_of_participant relationship type where an employment consists of exactly one
-         * {@link Employer}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where an
+         * {@link Employment} consists of exactly one {@link Employer}.
          *
-         * @param employer
-         * @return
+         * @param employer The Employer.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Employer employer) {
             employmentImpl.addValue(CONSISTS_OF_PARTICIPANT, employer.getIri());
@@ -113,11 +129,11 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
-         * A consists_of_participant relationship type where an employment consists of exactly one
-         * {@link Employee}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where an
+         * {@link Employment} consists of exactly one {@link Employee}.
          *
-         * @param employee
-         * @return
+         * @param employee The Employee.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant_(final Employee employee) {
             employmentImpl.addValue(CONSISTS_OF_PARTICIPANT_, employee.getIri());
@@ -125,9 +141,11 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             employmentImpl.addValue(ENDING, event.getIri());
@@ -135,9 +153,11 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             employmentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -145,9 +165,12 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Association} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfAssociation}.
          *
-         * @param classOfAssociation
-         * @return
+         * @param classOfAssociation The ClassOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAssociation classOfAssociation) {
             employmentImpl.addValue(MEMBER_OF, classOfAssociation.getIri());
@@ -155,9 +178,12 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Association} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfAssociation}.
          *
-         * @param kindOfAssociation
-         * @return
+         * @param kindOfAssociation The KindOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfAssociation kindOfAssociation) {
             employmentImpl.addValue(MEMBER_OF_KIND, kindOfAssociation.getIri());
@@ -165,9 +191,12 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employmentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -175,9 +204,17 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             employmentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -185,9 +222,12 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             employmentImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -195,9 +235,21 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             employmentImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -205,9 +257,10 @@ public class EmploymentImpl extends HqdmObject implements Employment {
         }
 
         /**
+         * Returns an instance of Employment created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Employment.
+         * @throws HqdmException If the Employment is missing any mandatory properties.
          */
         public Employment build() throws HqdmException {
             if (employmentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EndingOfOwnershipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EndingOfOwnershipImpl.java
@@ -40,32 +40,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnership {
     /**
+     * Constructs a new EndingOfOwnership.
      *
-     * @param iri
+     * @param iri IRI of the EndingOfOwnership.
      */
     public EndingOfOwnershipImpl(final IRI iri) {
         super(EndingOfOwnershipImpl.class, iri, ENDING_OF_OWNERSHIP);
     }
 
     /**
-     * Builder for EndingOfOwnershipImpl.
+     * Builder for constructing instances of EndingOfOwnership.
      */
     public static class Builder {
-        /** */
+
         private final EndingOfOwnershipImpl endingOfOwnershipImpl;
 
         /**
+         * Constructs a Builder for a new EndingOfOwnership.
          *
-         * @param iri
+         * @param iri IRI of the EndingOfOwnership.
          */
         public Builder(final IRI iri) {
             endingOfOwnershipImpl = new EndingOfOwnershipImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             endingOfOwnershipImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -73,9 +81,11 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             endingOfOwnershipImpl.addValue(BEGINNING, event.getIri());
@@ -83,9 +93,15 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             endingOfOwnershipImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -93,9 +109,11 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             endingOfOwnershipImpl.addValue(ENDING, event.getIri());
@@ -103,9 +121,11 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             endingOfOwnershipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -113,9 +133,11 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an {@link Event}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfEvent}.
          *
-         * @param classOfEvent
-         * @return
+         * @param classOfEvent The ClassOfEvent.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfEvent classOfEvent) {
             endingOfOwnershipImpl.addValue(MEMBER_OF, classOfEvent.getIri());
@@ -123,9 +145,12 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             endingOfOwnershipImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -133,9 +158,17 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             endingOfOwnershipImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -143,9 +176,12 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             endingOfOwnershipImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -153,9 +189,10 @@ public class EndingOfOwnershipImpl extends HqdmObject implements EndingOfOwnersh
         }
 
         /**
+         * Returns an instance of EndingOfOwnership created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built EndingOfOwnership.
+         * @throws HqdmException If the EndingOfOwnership is missing any mandatory properties.
          */
         public EndingOfOwnership build() throws HqdmException {
             if (endingOfOwnershipImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EnumeratedClassImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EnumeratedClassImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EnumeratedClassImpl extends HqdmObject implements EnumeratedClass {
     /**
+     * Constructs a new EnumeratedClass.
      *
-     * @param iri
+     * @param iri IRI of the EnumeratedClass.
      */
     public EnumeratedClassImpl(final IRI iri) {
         super(EnumeratedClassImpl.class, iri, ENUMERATED_CLASS);
     }
 
     /**
-     * Builder for EnumeratedClassImpl.
+     * Builder for constructing instances of EnumeratedClass.
      */
     public static class Builder {
-        /** */
+
         private final EnumeratedClassImpl enumeratedClassImpl;
 
         /**
+         * Constructs a Builder for a new EnumeratedClass.
          *
-         * @param iri
+         * @param iri IRI of the EnumeratedClass.
          */
         public Builder(final IRI iri) {
             enumeratedClassImpl = new EnumeratedClassImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             enumeratedClassImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class EnumeratedClassImpl extends HqdmObject implements EnumeratedClass {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             enumeratedClassImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class EnumeratedClassImpl extends HqdmObject implements EnumeratedClass {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             enumeratedClassImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,10 @@ public class EnumeratedClassImpl extends HqdmObject implements EnumeratedClass {
         }
 
         /**
+         * Returns an instance of EnumeratedClass created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built EnumeratedClass.
+         * @throws HqdmException If the EnumeratedClass is missing any mandatory properties.
          */
         public EnumeratedClass build() throws HqdmException {
             if (enumeratedClassImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/EventImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/EventImpl.java
@@ -39,32 +39,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class EventImpl extends HqdmObject implements Event {
     /**
+     * Constructs a new Event.
      *
-     * @param iri
+     * @param iri IRI of the Event.
      */
     public EventImpl(final IRI iri) {
         super(EventImpl.class, iri, EVENT);
     }
 
     /**
-     * Builder for EventImpl.
+     * Builder for constructing instances of Event.
      */
     public static class Builder {
-        /** */
+
         private final EventImpl eventImpl;
 
         /**
+         * Constructs a Builder for a new Event.
          *
-         * @param iri
+         * @param iri IRI of the Event.
          */
         public Builder(final IRI iri) {
             eventImpl = new EventImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             eventImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -72,9 +80,11 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             eventImpl.addValue(BEGINNING, event.getIri());
@@ -82,9 +92,15 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             eventImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -92,9 +108,11 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             eventImpl.addValue(ENDING, event.getIri());
@@ -102,9 +120,11 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             eventImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -112,11 +132,11 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
-         * A member_of relationship type where an event may be a member_of one or more
-         * {@link ClassOfEvent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an {@link Event}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfEvent}.
          *
-         * @param classOfEvent
-         * @return
+         * @param classOfEvent The ClassOfEvent.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfEvent classOfEvent) {
             eventImpl.addValue(MEMBER_OF, classOfEvent.getIri());
@@ -124,9 +144,12 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             eventImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -134,9 +157,17 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             eventImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -144,9 +175,12 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             eventImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -154,9 +188,10 @@ public class EventImpl extends HqdmObject implements Event {
         }
 
         /**
+         * Returns an instance of Event created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Event.
+         * @throws HqdmException If the Event is missing any mandatory properties.
          */
         public Event build() throws HqdmException {
             if (eventImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ExchangeOfGoodsAndMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ExchangeOfGoodsAndMoneyImpl.java
@@ -58,32 +58,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeOfGoodsAndMoney {
     /**
+     * Constructs a new ExchangeOfGoodsAndMoney.
      *
-     * @param iri
+     * @param iri IRI of the ExchangeOfGoodsAndMoney.
      */
     public ExchangeOfGoodsAndMoneyImpl(final IRI iri) {
         super(ExchangeOfGoodsAndMoneyImpl.class, iri, EXCHANGE_OF_GOODS_AND_MONEY);
     }
 
     /**
-     * Builder for ExchangeOfGoodsAndMoneyImpl.
+     * Builder for constructing instances of ExchangeOfGoodsAndMoney.
      */
     public static class Builder {
-        /** */
+
         private final ExchangeOfGoodsAndMoneyImpl exchangeOfGoodsAndMoneyImpl;
 
         /**
+         * Constructs a Builder for a new ExchangeOfGoodsAndMoney.
          *
-         * @param iri
+         * @param iri IRI of the ExchangeOfGoodsAndMoney.
          */
         public Builder(final IRI iri) {
             exchangeOfGoodsAndMoneyImpl = new ExchangeOfGoodsAndMoneyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             exchangeOfGoodsAndMoneyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -91,9 +99,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             exchangeOfGoodsAndMoneyImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +111,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             exchangeOfGoodsAndMoneyImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +123,15 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             exchangeOfGoodsAndMoneyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,11 +139,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
-         * A consists_of relationship type where an exchange_of_goods_and_money consists of exactly
-         * one {@link TransferOfOwnership} as a part.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link ExchangeOfGoodsAndMoney} consists of exactly one {@link TransferOfOwnership} as a
+         * part.
          *
-         * @param transferOfOwnership
-         * @return
+         * @param transferOfOwnership The TransferOfOwnership.
+         * @return Builder
          */
         public final Builder consists_Of(final TransferOfOwnership transferOfOwnership) {
             exchangeOfGoodsAndMoneyImpl.addValue(CONSISTS_OF, transferOfOwnership.getIri());
@@ -133,11 +152,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
-         * A consists_of relationship type where an exchange_of_goods_and_money consists of exactly
-         * one {@link TransferOfOwnershipOfMoney}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link ExchangeOfGoodsAndMoney} consists of exactly one
+         * {@link TransferOfOwnershipOfMoney}.
          *
-         * @param transferOfOwnershipOfMoney
-         * @return
+         * @param transferOfOwnershipOfMoney The TransferOfOwnershipOfMoney.
+         * @return Builder
          */
         public final Builder consists_Of_(
                 final TransferOfOwnershipOfMoney transferOfOwnershipOfMoney) {
@@ -146,9 +166,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             exchangeOfGoodsAndMoneyImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -156,9 +179,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             exchangeOfGoodsAndMoneyImpl.addValue(DETERMINES, thing.getIri());
@@ -166,9 +191,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             exchangeOfGoodsAndMoneyImpl.addValue(ENDING, event.getIri());
@@ -176,9 +203,10 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             exchangeOfGoodsAndMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -186,9 +214,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.ContractExecution} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfContractExecution}.
          *
-         * @param classOfContractExecution
-         * @return
+         * @param classOfContractExecution The ClassOfContractExecution.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfContractExecution classOfContractExecution) {
             exchangeOfGoodsAndMoneyImpl.addValue(MEMBER_OF, classOfContractExecution.getIri());
@@ -196,9 +227,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             exchangeOfGoodsAndMoneyImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -206,9 +240,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             exchangeOfGoodsAndMoneyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -216,11 +253,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
-         * A part_of relationship type where an exchange_of_goods_and_money is a part_of exactly one
-         * {@link SaleOfGoods}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link ExchangeOfGoodsAndMoney} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly
+         * one {@link SaleOfGoods}.
          *
-         * @param saleOfGoods
-         * @return
+         * @param saleOfGoods The SaleOfGoods.
+         * @return Builder
          */
         public final Builder part_Of_M(final SaleOfGoods saleOfGoods) {
             exchangeOfGoodsAndMoneyImpl.addValue(PART_OF, saleOfGoods.getIri());
@@ -228,9 +266,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             exchangeOfGoodsAndMoneyImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -238,9 +279,17 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             exchangeOfGoodsAndMoneyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -248,9 +297,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             exchangeOfGoodsAndMoneyImpl.addValue(REFERENCES, thing.getIri());
@@ -258,9 +309,12 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             exchangeOfGoodsAndMoneyImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -268,9 +322,21 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             exchangeOfGoodsAndMoneyImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -278,9 +344,11 @@ public class ExchangeOfGoodsAndMoneyImpl extends HqdmObject implements ExchangeO
         }
 
         /**
+         * Returns an instance of ExchangeOfGoodsAndMoney created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ExchangeOfGoodsAndMoney.
+         * @throws HqdmException If the ExchangeOfGoodsAndMoney is missing any mandatory properties.
          */
         public ExchangeOfGoodsAndMoney build() throws HqdmException {
             if (exchangeOfGoodsAndMoneyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionImpl.java
@@ -30,32 +30,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class FunctionImpl extends HqdmObject implements Function_ {
     /**
+     * Constructs a new Function_.
      *
-     * @param iri
+     * @param iri IRI of the Function_.
      */
     public FunctionImpl(final IRI iri) {
         super(FunctionImpl.class, iri, FUNCTION_);
     }
 
     /**
-     * Builder for FunctionImpl.
+     * Builder for constructing instances of Function.
      */
     public static class Builder {
-        /** */
+
         private final FunctionImpl functionImpl;
 
         /**
+         * Constructs a Builder for a new Function.
          *
-         * @param iri
+         * @param iri IRI of the Function.
          */
         public Builder(final IRI iri) {
             functionImpl = new FunctionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             functionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -63,9 +67,11 @@ public class FunctionImpl extends HqdmObject implements Function_ {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             functionImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -73,9 +79,10 @@ public class FunctionImpl extends HqdmObject implements Function_ {
         }
 
         /**
-         * 
-         * @return
-         * @throws HqdmException
+         * Builds the Function_.
+         *
+         * @return The built Function_.
+         * @throws HqdmException If the Function_ is missing any mandatory properties.
          */
         public Function_ build() throws HqdmException {
             if (functionImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalObjectImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject {
     /**
+     * Constructs a new FunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the FunctionalObject.
      */
     public FunctionalObjectImpl(final IRI iri) {
         super(FunctionalObjectImpl.class, iri, FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for FunctionalObjectImpl.
+     * Builder for constructing instances of FunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final FunctionalObjectImpl functionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new FunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the FunctionalObject.
          */
         public Builder(final IRI iri) {
             functionalObjectImpl = new FunctionalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             functionalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             functionalObjectImpl.addValue(ENDING, event.getIri());
@@ -109,10 +127,11 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
-         * A relationship type where a functional_object has one or more intended {@link Role}.
+         * A relationship type where a {@link FunctionalObject} has one or more intended
+         * {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_M(final Role role) {
             functionalObjectImpl.addValue(INTENDED_ROLE, role.getIri());
@@ -120,9 +139,11 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             functionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -130,11 +151,12 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
-         * A member_of relationship type where a functional_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link FunctionalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfFunctionalObject}.
          *
-         * @param classOfFunctionalObject
-         * @return
+         * @param classOfFunctionalObject The ClassOfFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfFunctionalObject classOfFunctionalObject) {
             functionalObjectImpl.addValue(MEMBER_OF, classOfFunctionalObject.getIri());
@@ -142,11 +164,12 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
-         * A member_of_kind relationship type where a functional_object may be a member_of one or
-         * more {@link KindOfFunctionalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link FunctionalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfFunctionalObject}.
          *
-         * @param kindOfFunctionalObject
-         * @return
+         * @param kindOfFunctionalObject The KindOfFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfFunctionalObject kindOfFunctionalObject) {
             functionalObjectImpl.addValue(MEMBER_OF_KIND, kindOfFunctionalObject.getIri());
@@ -154,9 +177,12 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -164,9 +190,17 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             functionalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -174,9 +208,12 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -184,9 +221,21 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             functionalObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -194,9 +243,10 @@ public class FunctionalObjectImpl extends HqdmObject implements FunctionalObject
         }
 
         /**
+         * Returns an instance of FunctionalObject created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built FunctionalObject.
+         * @throws HqdmException If the FunctionalObject is missing any mandatory properties.
          */
         public FunctionalObject build() throws HqdmException {
             if (functionalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalSystemComponentImpl.java
@@ -48,32 +48,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class FunctionalSystemComponentImpl extends HqdmObject implements FunctionalSystemComponent {
     /**
+     * Constructs a new FunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the FunctionalSystemComponent.
      */
     public FunctionalSystemComponentImpl(final IRI iri) {
         super(FunctionalSystemComponentImpl.class, iri, FUNCTIONAL_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for FunctionalSystemComponentImpl.
+     * Builder for constructing instances of FunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final FunctionalSystemComponentImpl functionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new FunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the FunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             functionalSystemComponentImpl = new FunctionalSystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -81,9 +89,11 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             functionalSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -91,11 +101,11 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
-         * A component_of relationship type where each functional_system_component is a component of
-         * exactly one {@link FunctionalSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#COMPONENT_OF} relationship type where each
+         * {@link FunctionalSystemComponent} is a component of exactly one {@link FunctionalSystem}.
          *
-         * @param functionalSystem
-         * @return
+         * @param functionalSystem The FunctionalSystem.
+         * @return This builder.
          */
         public final Builder component_Of_M(final FunctionalSystem functionalSystem) {
             functionalSystemComponentImpl.addValue(COMPONENT_OF, functionalSystem.getIri());
@@ -103,9 +113,15 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -113,9 +129,11 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             functionalSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -123,9 +141,11 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.FunctionalObject} has one or
+         * more intended {@link Role}(s).
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_M(final Role role) {
             functionalSystemComponentImpl.addValue(INTENDED_ROLE, role.getIri());
@@ -133,9 +153,11 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             functionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -143,11 +165,12 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
-         * A member_of relationship type where a functional_system_component may be a member_of one
-         * or more {@link ClassOfFunctionalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link FunctionalSystemComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link ClassOfFunctionalSystemComponent}.
          *
-         * @param classOfFunctionalSystemComponent
-         * @return
+         * @param classOfFunctionalSystemComponent The ClassOfFunctionalSystemComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfFunctionalSystemComponent classOfFunctionalSystemComponent) {
@@ -157,11 +180,12 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
-         * A member_of_kind relationship type where a functional_system_component is a member_of at
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link FunctionalSystemComponent} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} at
          * least one {@link KindOfFunctionalSystemComponent}.
          *
-         * @param kindOfFunctionalSystemComponent
-         * @return
+         * @param kindOfFunctionalSystemComponent The KindOfFunctionalSystemComponent.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(
                 final KindOfFunctionalSystemComponent kindOfFunctionalSystemComponent) {
@@ -171,9 +195,12 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -181,9 +208,17 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             functionalSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -191,9 +226,12 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -202,9 +240,21 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             functionalSystemComponentImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -212,9 +262,12 @@ public class FunctionalSystemComponentImpl extends HqdmObject implements Functio
         }
 
         /**
+         * Returns an instance of FunctionalSystemComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built FunctionalSystemComponent.
+         * @throws HqdmException If the FunctionalSystemComponent is missing any mandatory
+         *         properties.
          */
         public FunctionalSystemComponent build() throws HqdmException {
             if (functionalSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/FunctionalSystemImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem {
     /**
+     * Constructs a new FunctionalSystem.
      *
-     * @param iri
+     * @param iri IRI of the FunctionalSystem.
      */
     public FunctionalSystemImpl(final IRI iri) {
         super(FunctionalSystemImpl.class, iri, FUNCTIONAL_SYSTEM);
     }
 
     /**
-     * Builder for FunctionalSystemImpl.
+     * Builder for constructing instances of FunctionalSystem.
      */
     public static class Builder {
-        /** */
+
         private final FunctionalSystemImpl functionalSystemImpl;
 
         /**
+         * Constructs a Builder for a new FunctionalSystem.
          *
-         * @param iri
+         * @param iri IRI of the FunctionalSystem.
          */
         public Builder(final IRI iri) {
             functionalSystemImpl = new FunctionalSystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             functionalSystemImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             functionalSystemImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.FunctionalObject} has one or
+         * more intended {@link Role}(s).
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_M(final Role role) {
             functionalSystemImpl.addValue(INTENDED_ROLE, role.getIri());
@@ -119,9 +139,11 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             functionalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -129,11 +151,12 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
-         * A member_of relationship type where a functional_system may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link FunctionalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfFunctionalSystem}.
          *
-         * @param classOfFunctionalSystem
-         * @return
+         * @param classOfFunctionalSystem The ClassOfFunctionalSystem.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfFunctionalSystem classOfFunctionalSystem) {
             functionalSystemImpl.addValue(MEMBER_OF, classOfFunctionalSystem.getIri());
@@ -141,11 +164,12 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
-         * A member_of_kind relationship type where a functional_system may be a member_of one or
-         * more {@link KindOfFunctionalSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link FunctionalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfFunctionalSystem}.
          *
-         * @param kindOfFunctionalSystem
-         * @return
+         * @param kindOfFunctionalSystem The KindOfFunctionalSystem.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfFunctionalSystem kindOfFunctionalSystem) {
             functionalSystemImpl.addValue(MEMBER_OF_KIND, kindOfFunctionalSystem.getIri());
@@ -153,9 +177,12 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +190,17 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             functionalSystemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +208,12 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             functionalSystemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +221,12 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfSystem} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link System}.
          *
-         * @param system
-         * @return
+         * @param system The System.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final System system) {
             functionalSystemImpl.addValue(TEMPORAL_PART_OF, system.getIri());
@@ -193,9 +234,10 @@ public class FunctionalSystemImpl extends HqdmObject implements FunctionalSystem
         }
 
         /**
+         * Returns an instance of FunctionalSystem created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built FunctionalSystem.
+         * @throws HqdmException If the FunctionalSystem is missing any mandatory properties.
          */
         public FunctionalSystem build() throws HqdmException {
             if (functionalSystemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/IdentificationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/IdentificationImpl.java
@@ -32,32 +32,39 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class IdentificationImpl extends HqdmObject implements Identification {
     /**
+     * Constructs a new Identification.
      *
-     * @param iri
+     * @param iri IRI of the Identification.
      */
     public IdentificationImpl(final IRI iri) {
         super(IdentificationImpl.class, iri, IDENTIFICATION);
     }
 
     /**
-     * Builder for IdentificationImpl.
+     * Builder for constructing instances of Identification.
      */
     public static class Builder {
-        /** */
+
         private final IdentificationImpl identificationImpl;
 
         /**
+         * Constructs a Builder for a new Identification.
          *
-         * @param iri
+         * @param iri IRI of the Identification.
          */
         public Builder(final IRI iri) {
             identificationImpl = new IdentificationImpl(iri);
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern} has a
+         * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link Pattern}.
          *
-         * @param pattern
-         * @return
+         * @param pattern The Pattern.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class_M(final Pattern pattern) {
             identificationImpl.addValue(CONSISTS_OF_BY_CLASS, pattern.getIri());
@@ -65,9 +72,13 @@ public class IdentificationImpl extends HqdmObject implements Identification {
         }
 
         /**
+         * A relationship type where a {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_In_Members_M(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -77,9 +88,12 @@ public class IdentificationImpl extends HqdmObject implements Identification {
         }
 
         /**
+         * A relationship type where the thing is represented by each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder represented_M(final Thing thing) {
             identificationImpl.addValue(REPRESENTED, thing.getIri());
@@ -87,9 +101,10 @@ public class IdentificationImpl extends HqdmObject implements Identification {
         }
 
         /**
+         * Returns an instance of Identification created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Identification.
+         * @throws HqdmException If the Identification is missing any mandatory properties.
          */
         public Identification build() throws HqdmException {
             if (!identificationImpl.hasValue(CONSISTS_OF_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/IdentificationOfPhysicalQuantityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/IdentificationOfPhysicalQuantityImpl.java
@@ -34,34 +34,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class IdentificationOfPhysicalQuantityImpl extends HqdmObject
         implements IdentificationOfPhysicalQuantity {
     /**
+     * Constructs a new IdentificationOfPhysicalQuantity.
      *
-     * @param iri
+     * @param iri IRI of the IdentificationOfPhysicalQuantity.
      */
     public IdentificationOfPhysicalQuantityImpl(final IRI iri) {
         super(IdentificationOfPhysicalQuantityImpl.class, iri, IDENTIFICATION_OF_PHYSICAL_QUANTITY);
     }
 
     /**
-     * Builder for IdentificationOfPhysicalQuantityImpl.
+     * Builder for constructing instances of IdentificationOfPhysicalQuantity.
      */
     public static class Builder {
-        /** */
+
         private final IdentificationOfPhysicalQuantityImpl identificationOfPhysicalQuantityImpl;
 
         /**
+         * Constructs a Builder for a new IdentificationOfPhysicalQuantity.
          *
-         * @param iri
+         * @param iri IRI of the IdentificationOfPhysicalQuantity.
          */
         public Builder(final IRI iri) {
             identificationOfPhysicalQuantityImpl = new IdentificationOfPhysicalQuantityImpl(iri);
         }
 
         /**
-         * A relationship type where an identification_of_physical_quantity consists of exactly one
-         * REAL as its value.
+         * A relationship type where an {@link IdentificationOfPhysicalQuantity} consists of exactly
+         * one REAL as its value.
          *
-         * @param value
-         * @return
+         * @param value The Value.
+         * @return This builder.
          */
         public final Builder value__M(final double value) {
             identificationOfPhysicalQuantityImpl.addRealValue(VALUE_, value);
@@ -69,9 +71,13 @@ public class IdentificationOfPhysicalQuantityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link uk.gov.gchq.hqdm.model.RepresentationByPattern}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_In_Members_M(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -81,11 +87,11 @@ public class IdentificationOfPhysicalQuantityImpl extends HqdmObject
         }
 
         /**
-         * A relationship type where a member_of an identification_of_physical_quantity represents
-         * exactly one {@link PhysicalQuantity}.
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} an
+         * {@link IdentificationOfPhysicalQuantity} represents exactly one {@link PhysicalQuantity}.
          *
-         * @param physicalQuantity
-         * @return
+         * @param physicalQuantity The PhysicalQuantity.
+         * @return This builder.
          */
         public final Builder represented_M(final PhysicalQuantity physicalQuantity) {
             identificationOfPhysicalQuantityImpl.addValue(REPRESENTED, physicalQuantity.getIri());
@@ -93,11 +99,11 @@ public class IdentificationOfPhysicalQuantityImpl extends HqdmObject
         }
 
         /**
-         * A relationship type where an identification_of_physical_quantity uses exactly one
+         * A relationship type where an {@link IdentificationOfPhysicalQuantity} uses exactly one
          * {@link Scale}.
          *
-         * @param scale
-         * @return
+         * @param scale The Scale.
+         * @return This builder.
          */
         public final Builder uses_M(final Scale scale) {
             identificationOfPhysicalQuantityImpl.addValue(USES, scale.getIri());
@@ -105,9 +111,12 @@ public class IdentificationOfPhysicalQuantityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of IdentificationOfPhysicalQuantity created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built IdentificationOfPhysicalQuantity.
+         * @throws HqdmException If the IdentificationOfPhysicalQuantity is missing any mandatory
+         *         properties.
          */
         public IdentificationOfPhysicalQuantity build() throws HqdmException {
             if (!identificationOfPhysicalQuantityImpl.hasValue(VALUE_)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/InPlaceBiologicalComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/InPlaceBiologicalComponentImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class InPlaceBiologicalComponentImpl extends HqdmObject
         implements InPlaceBiologicalComponent {
     /**
+     * Constructs a new InPlaceBiologicalComponent.
      *
-     * @param iri
+     * @param iri IRI of the InPlaceBiologicalComponent.
      */
     public InPlaceBiologicalComponentImpl(final IRI iri) {
         super(InPlaceBiologicalComponentImpl.class, iri, IN_PLACE_BIOLOGICAL_COMPONENT);
     }
 
     /**
-     * Builder for InPlaceBiologicalComponentImpl.
+     * Builder for constructing instances of InPlaceBiologicalComponent.
      */
     public static class Builder {
-        /** */
+
         private final InPlaceBiologicalComponentImpl inPlaceBiologicalComponentImpl;
 
         /**
+         * Constructs a Builder for a new InPlaceBiologicalComponent.
          *
-         * @param iri
+         * @param iri IRI of the InPlaceBiologicalComponent.
          */
         public Builder(final IRI iri) {
             inPlaceBiologicalComponentImpl = new InPlaceBiologicalComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             inPlaceBiologicalComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             inPlaceBiologicalComponentImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             inPlaceBiologicalComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             inPlaceBiologicalComponentImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             inPlaceBiologicalComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where an in_place_biological_component may be a member_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link InPlaceBiologicalComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
          * one or more {@link ClassOfInPlaceBiologicalComponent}.
          *
-         * @param classOfInPlaceBiologicalComponent
-         * @return
+         * @param classOfInPlaceBiologicalComponent The ClassOfInPlaceBiologicalComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfInPlaceBiologicalComponent classOfInPlaceBiologicalComponent) {
@@ -130,9 +151,12 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             inPlaceBiologicalComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -140,9 +164,17 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             inPlaceBiologicalComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -150,9 +182,12 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             inPlaceBiologicalComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -161,9 +196,13 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfBiologicalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link BiologicalSystemComponent}.
          *
-         * @param biologicalSystemComponent
-         * @return
+         * @param biologicalSystemComponent The BiologicalSystemComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final BiologicalSystemComponent biologicalSystemComponent) {
@@ -173,9 +212,12 @@ public class InPlaceBiologicalComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of InPlaceBiologicalComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built InPlaceBiologicalComponent.
+         * @throws HqdmException If the InPlaceBiologicalComponent is missing any mandatory
+         *         properties.
          */
         public InPlaceBiologicalComponent build() throws HqdmException {
             if (inPlaceBiologicalComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/IndividualImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/IndividualImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class IndividualImpl extends HqdmObject implements Individual {
     /**
+     * Constructs a new Individual.
      *
-     * @param iri
+     * @param iri IRI of the Individual.
      */
     public IndividualImpl(final IRI iri) {
         super(IndividualImpl.class, iri, INDIVIDUAL);
     }
 
     /**
-     * Builder for IndividualImpl.
+     * Builder for constructing instances of Individual.
      */
     public static class Builder {
-        /** */
+
         private final IndividualImpl individualImpl;
 
         /**
+         * Constructs a Builder for a new Individual.
          *
-         * @param iri
+         * @param iri IRI of the Individual.
          */
         public Builder(final IRI iri) {
             individualImpl = new IndividualImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             individualImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             individualImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             individualImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             individualImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             individualImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
-         * A member_of_relationship type where an individual may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link Individual} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfIndividual}.
          *
-         * @param classOfIndividual
-         * @return
+         * @param classOfIndividual The ClassOfIndividual.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfIndividual classOfIndividual) {
             individualImpl.addValue(MEMBER_OF, classOfIndividual.getIri());
@@ -128,11 +149,12 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
-         * A member_of relationship type where an individual may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link Individual} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfIndividual}.
          *
-         * @param kindOfIndividual
-         * @return
+         * @param kindOfIndividual The KindOfIndividual.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfIndividual kindOfIndividual) {
             individualImpl.addValue(MEMBER_OF_KIND, kindOfIndividual.getIri());
@@ -140,9 +162,12 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             individualImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,9 +175,17 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             individualImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -160,9 +193,12 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             individualImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -170,9 +206,21 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             individualImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -180,9 +228,10 @@ public class IndividualImpl extends HqdmObject implements Individual {
         }
 
         /**
+         * Returns an instance of Individual created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Individual.
+         * @throws HqdmException If the Individual is missing any mandatory properties.
          */
         public Individual build() throws HqdmException {
             if (individualImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/InstalledFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/InstalledFunctionalSystemComponentImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         implements InstalledFunctionalSystemComponent {
     /**
+     * Constructs a new InstalledFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the InstalledFunctionalSystemComponent.
      */
     public InstalledFunctionalSystemComponentImpl(final IRI iri) {
         super(InstalledFunctionalSystemComponentImpl.class, iri,
@@ -52,15 +53,16 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for InstalledFunctionalSystemComponentImpl.
+     * Builder for constructing instances of InstalledFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final InstalledFunctionalSystemComponentImpl installedFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new InstalledFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the InstalledFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             installedFunctionalSystemComponentImpl =
@@ -68,9 +70,15 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             installedFunctionalSystemComponentImpl.addValue(AGGREGATED_INTO,
@@ -79,9 +87,11 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             installedFunctionalSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedFunctionalSystemComponentImpl.addValue(CONSISTS__OF,
@@ -100,9 +116,11 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             installedFunctionalSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -110,9 +128,11 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             installedFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -120,11 +140,14 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where an installed_functional_system_component may be a
-         * member_of one or more {@link ClassOfInstalledFunctionalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link InstalledFunctionalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfInstalledFunctionalSystemComponent}.
          *
          * @param classOfInstalledFunctionalSystemComponent
-         * @return
+         *        classOfInstalledFunctionalSystemComponent.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -135,9 +158,12 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedFunctionalSystemComponentImpl.addValue(PART__OF,
@@ -146,9 +172,17 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             installedFunctionalSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -157,9 +191,12 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedFunctionalSystemComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -168,9 +205,13 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfFunctionalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link FunctionalSystemComponent}.
          *
-         * @param functionalSystemComponent
-         * @return
+         * @param functionalSystemComponent The FunctionalSystemComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final FunctionalSystemComponent functionalSystemComponent) {
@@ -180,9 +221,12 @@ public class InstalledFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of InstalledFunctionalSystemComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built InstalledFunctionalSystemComponent.
+         * @throws HqdmException If the InstalledFunctionalSystemComponent is missing any mandatory
+         *         properties.
          */
         public InstalledFunctionalSystemComponent build() throws HqdmException {
             if (installedFunctionalSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/InstalledObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/InstalledObjectImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
     /**
+     * Constructs a new InstalledObject.
      *
-     * @param iri
+     * @param iri IRI of the InstalledObject.
      */
     public InstalledObjectImpl(final IRI iri) {
         super(InstalledObjectImpl.class, iri, INSTALLED_OBJECT);
     }
 
     /**
-     * Builder for InstalledObjectImpl.
+     * Builder for constructing instances of InstalledObject.
      */
     public static class Builder {
-        /** */
+
         private final InstalledObjectImpl installedObjectImpl;
 
         /**
+         * Constructs a Builder for a new InstalledObject.
          *
-         * @param iri
+         * @param iri IRI of the InstalledObject.
          */
         public Builder(final IRI iri) {
             installedObjectImpl = new InstalledObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             installedObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             installedObjectImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             installedObjectImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             installedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
-         * A member_of relationship type where an installed_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link InstalledObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfInstalledObject}.
          *
-         * @param classOfInstalledObject
-         * @return
+         * @param classOfInstalledObject The ClassOfInstalledObject.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfInstalledObject classOfInstalledObject) {
             installedObjectImpl.addValue(MEMBER_OF, classOfInstalledObject.getIri());
@@ -127,9 +148,12 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             installedObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             installedObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,9 +192,13 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryPhysicalObject}.
          *
-         * @param ordinaryPhysicalObject
-         * @return
+         * @param ordinaryPhysicalObject The OrdinaryPhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final OrdinaryPhysicalObject ordinaryPhysicalObject) {
             installedObjectImpl.addValue(TEMPORAL_PART_OF, ordinaryPhysicalObject.getIri());
@@ -167,9 +206,10 @@ public class InstalledObjectImpl extends HqdmObject implements InstalledObject {
         }
 
         /**
+         * Returns an instance of InstalledObject created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built InstalledObject.
+         * @throws HqdmException If the InstalledObject is missing any mandatory properties.
          */
         public InstalledObject build() throws HqdmException {
             if (installedObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/IntentionallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/IntentionallyConstructedObjectImpl.java
@@ -45,32 +45,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class IntentionallyConstructedObjectImpl extends HqdmObject
         implements IntentionallyConstructedObject {
     /**
+     * Constructs a new IntentionallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the IntentionallyConstructedObject.
      */
     public IntentionallyConstructedObjectImpl(final IRI iri) {
         super(IntentionallyConstructedObjectImpl.class, iri, INTENTIONALLY_CONSTRUCTED_OBJECT);
     }
 
     /**
-     * Builder for IntentionallyConstructedObjectImpl.
+     * Builder for constructing instances of IntentionallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         private final IntentionallyConstructedObjectImpl intentionallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new IntentionallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the IntentionallyConstructedObject.
          */
         public Builder(final IRI iri) {
             intentionallyConstructedObjectImpl = new IntentionallyConstructedObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             intentionallyConstructedObjectImpl.addValue(AGGREGATED_INTO,
@@ -79,9 +87,11 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             intentionallyConstructedObjectImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             intentionallyConstructedObjectImpl.addValue(CONSISTS__OF,
@@ -100,9 +116,11 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             intentionallyConstructedObjectImpl.addValue(ENDING, event.getIri());
@@ -110,9 +128,11 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             intentionallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -120,11 +140,13 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where an intentionally_constructed_object may be a
-         * member_of one or more {@link ClassOfIntentionallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link IntentionallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfIntentionallyConstructedObject}.
          *
-         * @param classOfIntentionallyConstructedObject
-         * @return
+         * @param classOfIntentionallyConstructedObject The ClassOfIntentionallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfIntentionallyConstructedObject classOfIntentionallyConstructedObject) {
@@ -134,11 +156,13 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of_kind relationship type where an intentionally_constructed_object may be a
-         * member_of one or more {@link KindOfIntentionallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where an
+         * {@link IntentionallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfIntentionallyConstructedObject}.
          *
-         * @param kindOfIntentionallyConstructedObject
-         * @return
+         * @param kindOfIntentionallyConstructedObject The KindOfIntentionallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfIntentionallyConstructedObject kindOfIntentionallyConstructedObject) {
@@ -148,9 +172,12 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             intentionallyConstructedObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -158,9 +185,17 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             intentionallyConstructedObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -169,9 +204,12 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             intentionallyConstructedObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -180,9 +218,21 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             intentionallyConstructedObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -190,9 +240,12 @@ public class IntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of IntentionallyConstructedObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built IntentionallyConstructedObject.
+         * @throws HqdmException If the IntentionallyConstructedObject is missing any mandatory
+         *         properties.
          */
         public IntentionallyConstructedObject build() throws HqdmException {
             if (intentionallyConstructedObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfActivityImpl.java
@@ -42,34 +42,37 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
     /**
+     * Constructs a new KindOfActivity.
      *
-     * @param iri
+     * @param iri IRI of the KindOfActivity.
      */
     public KindOfActivityImpl(final IRI iri) {
         super(KindOfActivityImpl.class, iri, KIND_OF_ACTIVITY);
     }
 
     /**
-     * Builder for KindOfActivityImpl.
+     * Builder for constructing instances of KindOfActivity.
      */
     public static class Builder {
-        /** */
+
         private final KindOfActivityImpl kindOfActivityImpl;
 
         /**
+         * Constructs a Builder for a new KindOfActivity.
          *
-         * @param iri
+         * @param iri IRI of the KindOfActivity.
          */
         public Builder(final IRI iri) {
             kindOfActivityImpl = new KindOfActivityImpl(iri);
         }
 
         /**
-         * A relationship type where a member_of the kind_of_activity causes a member_of the
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link KindOfActivity} causes a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
          * {@link ClassOfEvent}.
          *
-         * @param classOfEvent
-         * @return
+         * @param classOfEvent The ClassOfEvent.
+         * @return This builder.
          */
         public final Builder causes_By_Class(final ClassOfEvent classOfEvent) {
             kindOfActivityImpl.addValue(CAUSES_BY_CLASS, classOfEvent.getIri());
@@ -77,9 +80,13 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -89,11 +96,13 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
-         * A consists_of_by_class relationship type where a member_of a kind_of_activity has a
-         * member_of a {@link Role} as a participant.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link KindOfActivity} has a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link Role} as a
+         * {@link uk.gov.gchq.hqdm.model.Participant}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class(final Role role) {
             kindOfActivityImpl.addValue(CONSISTS_OF_BY_CLASS, role.getIri());
@@ -101,11 +110,12 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
-         * A relationship type where a member_of the kind_of_activity determines a member_of the
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link KindOfActivity} determines a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
          * {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder determines_By_Class(final Class clazz) {
             kindOfActivityImpl.addValue(DETERMINES_BY_CLASS, clazz.getIri());
@@ -113,9 +123,11 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfActivityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -123,9 +135,11 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -133,9 +147,11 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfActivityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -143,9 +159,12 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -154,9 +173,12 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -165,11 +187,12 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
-         * A relationship type where a member_of the kind_of_activity references a member_of the
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link KindOfActivity} references a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
          * {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder references_By_Class(final Class clazz) {
             kindOfActivityImpl.addValue(REFERENCES_BY_CLASS, clazz.getIri());
@@ -177,9 +200,10 @@ public class KindOfActivityImpl extends HqdmObject implements KindOfActivity {
         }
 
         /**
+         * Returns an instance of KindOfActivity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfActivity.
+         * @throws HqdmException If the KindOfActivity is missing any mandatory properties.
          */
         public KindOfActivity build() throws HqdmException {
             if (kindOfActivityImpl.hasValue(CAUSES_BY_CLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfAssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfAssociationImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociation {
     /**
+     * Constructs a new KindOfAssociation.
      *
-     * @param iri
+     * @param iri IRI of the KindOfAssociation.
      */
     public KindOfAssociationImpl(final IRI iri) {
         super(KindOfAssociationImpl.class, iri, KIND_OF_ASSOCIATION);
     }
 
     /**
-     * Builder for KindOfAssociationImpl.
+     * Builder for constructing instances of KindOfAssociation.
      */
     public static class Builder {
-        /** */
+
         private final KindOfAssociationImpl kindOfAssociationImpl;
 
         /**
+         * Constructs a Builder for a new KindOfAssociation.
          *
-         * @param iri
+         * @param iri IRI of the KindOfAssociation.
          */
         public Builder(final IRI iri) {
             kindOfAssociationImpl = new KindOfAssociationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,11 +79,12 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
-         * A consists_of_by_class relationship type where a member_of the kind_of_association has a
-         * member_of the {@link Role} as a part.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link KindOfAssociation} has a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link Role} as a part.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class(final Role role) {
             kindOfAssociationImpl.addValue(CONSISTS_OF_BY_CLASS, role.getIri());
@@ -85,9 +92,11 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfAssociationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -95,9 +104,11 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfAssociationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -105,9 +116,11 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfAssociationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -115,9 +128,12 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -126,9 +142,12 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -137,9 +156,10 @@ public class KindOfAssociationImpl extends HqdmObject implements KindOfAssociati
         }
 
         /**
+         * Returns an instance of KindOfAssociation created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfAssociation.
+         * @throws HqdmException If the KindOfAssociation is missing any mandatory properties.
          */
         public KindOfAssociation build() throws HqdmException {
             if (kindOfAssociationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiologicalObject {
     /**
+     * Constructs a new KindOfBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfBiologicalObject.
      */
     public KindOfBiologicalObjectImpl(final IRI iri) {
         super(KindOfBiologicalObjectImpl.class, iri, KIND_OF_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfBiologicalObjectImpl.
+     * Builder for constructing instances of KindOfBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfBiologicalObjectImpl kindOfBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfBiologicalObject.
          */
         public Builder(final IRI iri) {
             kindOfBiologicalObjectImpl = new KindOfBiologicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class KindOfBiologicalObjectImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * Returns an instance of KindOfBiologicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfBiologicalObject.
+         * @throws HqdmException If the KindOfBiologicalObject is missing any mandatory properties.
          */
         public KindOfBiologicalObject build() throws HqdmException {
             if (kindOfBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalSystemComponentImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         implements KindOfBiologicalSystemComponent {
     /**
+     * Constructs a new KindOfBiologicalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the KindOfBiologicalSystemComponent.
      */
     public KindOfBiologicalSystemComponentImpl(final IRI iri) {
         super(KindOfBiologicalSystemComponentImpl.class, iri, KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for KindOfBiologicalSystemComponentImpl.
+     * Builder for constructing instances of KindOfBiologicalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final KindOfBiologicalSystemComponentImpl kindOfBiologicalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new KindOfBiologicalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the KindOfBiologicalSystemComponent.
          */
         public Builder(final IRI iri) {
             kindOfBiologicalSystemComponentImpl = new KindOfBiologicalSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfBiologicalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfBiologicalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfBiologicalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfBiologicalSystemComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfBiologicalSystemComponent.
+         * @throws HqdmException If the KindOfBiologicalSystemComponent is missing any mandatory
+         *         properties.
          */
         public KindOfBiologicalSystemComponent build() throws HqdmException {
             if (kindOfBiologicalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfBiologicalSystemImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiologicalSystem {
     /**
+     * Constructs a new KindOfBiologicalSystem.
      *
-     * @param iri
+     * @param iri IRI of the KindOfBiologicalSystem.
      */
     public KindOfBiologicalSystemImpl(final IRI iri) {
         super(KindOfBiologicalSystemImpl.class, iri, KIND_OF_BIOLOGICAL_SYSTEM);
     }
 
     /**
-     * Builder for KindOfBiologicalSystemImpl.
+     * Builder for constructing instances of KindOfBiologicalSystem.
      */
     public static class Builder {
-        /** */
+
         private final KindOfBiologicalSystemImpl kindOfBiologicalSystemImpl;
 
         /**
+         * Constructs a Builder for a new KindOfBiologicalSystem.
          *
-         * @param iri
+         * @param iri IRI of the KindOfBiologicalSystem.
          */
         public Builder(final IRI iri) {
             kindOfBiologicalSystemImpl = new KindOfBiologicalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,12 +81,13 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
-         * A has_component_by_class relationship type where each member_of a
-         * kind_of_biological_system has a member_of one or more
+         * A has_component_by_class relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link KindOfBiologicalSystem} has a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfBiologicalSystemComponent} as a component.
          *
-         * @param kindOfBiologicalSystemComponent
-         * @return
+         * @param kindOfBiologicalSystemComponent The KindOfBiologicalSystemComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfBiologicalSystemComponent kindOfBiologicalSystemComponent) {
@@ -90,9 +97,11 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfBiologicalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -100,9 +109,11 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfBiologicalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -110,9 +121,11 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfBiologicalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -120,9 +133,12 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -132,11 +148,11 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
-         * A relationship type where each member_of the kind_of_biological_system naturally
-         * participates in the {@link Role}.
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link KindOfBiologicalSystem} naturally participates in the {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder natural_Role_By_Class_M(final Role role) {
             kindOfBiologicalSystemImpl.addValue(NATURAL_ROLE_BY_CLASS, role.getIri());
@@ -144,9 +160,12 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -156,9 +175,11 @@ public class KindOfBiologicalSystemImpl extends HqdmObject implements KindOfBiol
         }
 
         /**
+         * Returns an instance of KindOfBiologicalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfBiologicalSystem.
+         * @throws HqdmException If the KindOfBiologicalSystem is missing any mandatory properties.
          */
         public KindOfBiologicalSystem build() throws HqdmException {
             if (!kindOfBiologicalSystemImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalObjectImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunctionalObject {
     /**
+     * Constructs a new KindOfFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfFunctionalObject.
      */
     public KindOfFunctionalObjectImpl(final IRI iri) {
         super(KindOfFunctionalObjectImpl.class, iri, KIND_OF_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfFunctionalObjectImpl.
+     * Builder for constructing instances of KindOfFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfFunctionalObjectImpl kindOfFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfFunctionalObject.
          */
         public Builder(final IRI iri) {
             kindOfFunctionalObjectImpl = new KindOfFunctionalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,11 +91,11 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
-         * A relationship type where each member_of a kind_of_functional_object is intended to play
-         * one or more {@link Role}.
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link KindOfFunctionalObject} is intended to play one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_By_Class_M(final Role role) {
             kindOfFunctionalObjectImpl.addValue(INTENDED_ROLE_BY_CLASS, role.getIri());
@@ -95,9 +103,11 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -105,9 +115,11 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -115,9 +127,12 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -127,9 +142,12 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -139,9 +157,11 @@ public class KindOfFunctionalObjectImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * Returns an instance of KindOfFunctionalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfFunctionalObject.
+         * @throws HqdmException If the KindOfFunctionalObject is missing any mandatory properties.
          */
         public KindOfFunctionalObject build() throws HqdmException {
             if (kindOfFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalSystemComponentImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         implements KindOfFunctionalSystemComponent {
     /**
+     * Constructs a new KindOfFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the KindOfFunctionalSystemComponent.
      */
     public KindOfFunctionalSystemComponentImpl(final IRI iri) {
         super(KindOfFunctionalSystemComponentImpl.class, iri, KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for KindOfFunctionalSystemComponentImpl.
+     * Builder for constructing instances of KindOfFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final KindOfFunctionalSystemComponentImpl kindOfFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new KindOfFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the KindOfFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             kindOfFunctionalSystemComponentImpl = new KindOfFunctionalSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfFunctionalSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfFunctionalSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfFunctionalSystemComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfFunctionalSystemComponent.
+         * @throws HqdmException If the KindOfFunctionalSystemComponent is missing any mandatory
+         *         properties.
          */
         public KindOfFunctionalSystemComponent build() throws HqdmException {
             if (kindOfFunctionalSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfFunctionalSystemImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunctionalSystem {
     /**
+     * Constructs a new KindOfFunctionalSystem.
      *
-     * @param iri
+     * @param iri IRI of the KindOfFunctionalSystem.
      */
     public KindOfFunctionalSystemImpl(final IRI iri) {
         super(KindOfFunctionalSystemImpl.class, iri, KIND_OF_FUNCTIONAL_SYSTEM);
     }
 
     /**
-     * Builder for KindOfFunctionalSystemImpl.
+     * Builder for constructing instances of KindOfFunctionalSystem.
      */
     public static class Builder {
-        /** */
+
         private final KindOfFunctionalSystemImpl kindOfFunctionalSystemImpl;
 
         /**
+         * Constructs a Builder for a new KindOfFunctionalSystem.
          *
-         * @param iri
+         * @param iri IRI of the KindOfFunctionalSystem.
          */
         public Builder(final IRI iri) {
             kindOfFunctionalSystemImpl = new KindOfFunctionalSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,12 +79,13 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
-         * A has_component_by_class relationship type where each member_of the
-         * kind_of_functional_system has a member_of one or more
+         * A has_component_by_class relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link KindOfFunctionalSystem} has a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfFunctionalSystemComponent} as a component.
          *
-         * @param kindOfFunctionalSystemComponent
-         * @return
+         * @param kindOfFunctionalSystemComponent The KindOfFunctionalSystemComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfFunctionalSystemComponent kindOfFunctionalSystemComponent) {
@@ -88,9 +95,11 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfFunctionalSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -98,9 +107,11 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfFunctionalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -108,9 +119,11 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfFunctionalSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -118,9 +131,12 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -130,9 +146,12 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -142,9 +161,11 @@ public class KindOfFunctionalSystemImpl extends HqdmObject implements KindOfFunc
         }
 
         /**
+         * Returns an instance of KindOfFunctionalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfFunctionalSystem.
+         * @throws HqdmException If the KindOfFunctionalSystem is missing any mandatory properties.
          */
         public KindOfFunctionalSystem build() throws HqdmException {
             if (!kindOfFunctionalSystemImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfIndividualImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfIndividualImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual {
     /**
+     * Constructs a new KindOfIndividual.
      *
-     * @param iri
+     * @param iri IRI of the KindOfIndividual.
      */
     public KindOfIndividualImpl(final IRI iri) {
         super(KindOfIndividualImpl.class, iri, KIND_OF_INDIVIDUAL);
     }
 
     /**
-     * Builder for KindOfIndividualImpl.
+     * Builder for constructing instances of KindOfIndividual.
      */
     public static class Builder {
-        /** */
+
         private final KindOfIndividualImpl kindOfIndividualImpl;
 
         /**
+         * Constructs a Builder for a new KindOfIndividual.
          *
-         * @param iri
+         * @param iri IRI of the KindOfIndividual.
          */
         public Builder(final IRI iri) {
             kindOfIndividualImpl = new KindOfIndividualImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfIndividualImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfIndividualImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfIndividualImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class KindOfIndividualImpl extends HqdmObject implements KindOfIndividual
         }
 
         /**
+         * Returns an instance of KindOfIndividual created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfIndividual.
+         * @throws HqdmException If the KindOfIndividual is missing any mandatory properties.
          */
         public KindOfIndividual build() throws HqdmException {
             if (kindOfIndividualImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfIntentionallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfIntentionallyConstructedObjectImpl.java
@@ -37,8 +37,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         implements KindOfIntentionallyConstructedObject {
     /**
+     * Constructs a new KindOfIntentionallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfIntentionallyConstructedObject.
      */
     public KindOfIntentionallyConstructedObjectImpl(final IRI iri) {
         super(KindOfIntentionallyConstructedObjectImpl.class, iri,
@@ -46,16 +47,17 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for KindOfIntentionallyConstructedObjectImpl.
+     * Builder for constructing instances of KindOfIntentionallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final KindOfIntentionallyConstructedObjectImpl kindOfIntentionallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfIntentionallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfIntentionallyConstructedObject.
          */
         public Builder(final IRI iri) {
             kindOfIntentionallyConstructedObjectImpl =
@@ -63,9 +65,13 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -75,9 +81,11 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfIntentionallyConstructedObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -85,9 +93,11 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfIntentionallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -95,9 +105,11 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfIntentionallyConstructedObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -105,9 +117,12 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -117,9 +132,12 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -129,9 +147,12 @@ public class KindOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfIntentionallyConstructedObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfIntentionallyConstructedObject.
+         * @throws HqdmException If the KindOfIntentionallyConstructedObject is missing any
+         *         mandatory properties.
          */
         public KindOfIntentionallyConstructedObject build() throws HqdmException {
             if (kindOfIntentionallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryBiologicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         implements KindOfOrdinaryBiologicalObject {
     /**
+     * Constructs a new KindOfOrdinaryBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfOrdinaryBiologicalObject.
      */
     public KindOfOrdinaryBiologicalObjectImpl(final IRI iri) {
         super(KindOfOrdinaryBiologicalObjectImpl.class, iri, KIND_OF_ORDINARY_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfOrdinaryBiologicalObjectImpl.
+     * Builder for constructing instances of KindOfOrdinaryBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfOrdinaryBiologicalObjectImpl kindOfOrdinaryBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfOrdinaryBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfOrdinaryBiologicalObject.
          */
         public Builder(final IRI iri) {
             kindOfOrdinaryBiologicalObjectImpl = new KindOfOrdinaryBiologicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfOrdinaryBiologicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfOrdinaryBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfOrdinaryBiologicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfOrdinaryBiologicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfOrdinaryBiologicalObject.
+         * @throws HqdmException If the KindOfOrdinaryBiologicalObject is missing any mandatory
+         *         properties.
          */
         public KindOfOrdinaryBiologicalObject build() throws HqdmException {
             if (kindOfOrdinaryBiologicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryFunctionalObjectImpl.java
@@ -39,32 +39,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         implements KindOfOrdinaryFunctionalObject {
     /**
+     * Constructs a new KindOfOrdinaryFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfOrdinaryFunctionalObject.
      */
     public KindOfOrdinaryFunctionalObjectImpl(final IRI iri) {
         super(KindOfOrdinaryFunctionalObjectImpl.class, iri, KIND_OF_ORDINARY_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfOrdinaryFunctionalObjectImpl.
+     * Builder for constructing instances of KindOfOrdinaryFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfOrdinaryFunctionalObjectImpl kindOfOrdinaryFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfOrdinaryFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfOrdinaryFunctionalObject.
          */
         public Builder(final IRI iri) {
             kindOfOrdinaryFunctionalObjectImpl = new KindOfOrdinaryFunctionalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfOrdinaryFunctionalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +92,12 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.KindOfFunctionalObject} is intended to play one or more
+         * {@link Role}(s).
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_By_Class_M(final Role role) {
             kindOfOrdinaryFunctionalObjectImpl.addValue(INTENDED_ROLE_BY_CLASS, role.getIri());
@@ -94,9 +105,11 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfOrdinaryFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -104,9 +117,11 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfOrdinaryFunctionalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -114,9 +129,12 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -138,9 +159,12 @@ public class KindOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfOrdinaryFunctionalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfOrdinaryFunctionalObject.
+         * @throws HqdmException If the KindOfOrdinaryFunctionalObject is missing any mandatory
+         *         properties.
          */
         public KindOfOrdinaryFunctionalObject build() throws HqdmException {
             if (kindOfOrdinaryFunctionalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrdinaryPhysicalObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         implements KindOfOrdinaryPhysicalObject {
     /**
+     * Constructs a new KindOfOrdinaryPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfOrdinaryPhysicalObject.
      */
     public KindOfOrdinaryPhysicalObjectImpl(final IRI iri) {
         super(KindOfOrdinaryPhysicalObjectImpl.class, iri, KIND_OF_ORDINARY_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfOrdinaryPhysicalObjectImpl.
+     * Builder for constructing instances of KindOfOrdinaryPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfOrdinaryPhysicalObjectImpl kindOfOrdinaryPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfOrdinaryPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfOrdinaryPhysicalObject.
          */
         public Builder(final IRI iri) {
             kindOfOrdinaryPhysicalObjectImpl = new KindOfOrdinaryPhysicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfOrdinaryPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfOrdinaryPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfOrdinaryPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfOrdinaryPhysicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfOrdinaryPhysicalObject.
+         * @throws HqdmException If the KindOfOrdinaryPhysicalObject is missing any mandatory
+         *         properties.
          */
         public KindOfOrdinaryPhysicalObject build() throws HqdmException {
             if (kindOfOrdinaryPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrganizationComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrganizationComponentImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfOrganizationComponentImpl extends HqdmObject
         implements KindOfOrganizationComponent {
     /**
+     * Constructs a new KindOfOrganizationComponent.
      *
-     * @param iri
+     * @param iri IRI of the KindOfOrganizationComponent.
      */
     public KindOfOrganizationComponentImpl(final IRI iri) {
         super(KindOfOrganizationComponentImpl.class, iri, KIND_OF_ORGANIZATION_COMPONENT);
     }
 
     /**
-     * Builder for KindOfOrganizationComponentImpl.
+     * Builder for constructing instances of KindOfOrganizationComponent.
      */
     public static class Builder {
-        /** */
+
         private final KindOfOrganizationComponentImpl kindOfOrganizationComponentImpl;
 
         /**
+         * Constructs a Builder for a new KindOfOrganizationComponent.
          *
-         * @param iri
+         * @param iri IRI of the KindOfOrganizationComponent.
          */
         public Builder(final IRI iri) {
             kindOfOrganizationComponentImpl = new KindOfOrganizationComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfOrganizationComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfOrganizationComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfOrganizationComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfOrganizationComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfOrganizationComponent.
+         * @throws HqdmException If the KindOfOrganizationComponent is missing any mandatory
+         *         properties.
          */
         public KindOfOrganizationComponent build() throws HqdmException {
             if (kindOfOrganizationComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrganizationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfOrganizationImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganization {
     /**
+     * Constructs a new KindOfOrganization.
      *
-     * @param iri
+     * @param iri IRI of the KindOfOrganization.
      */
     public KindOfOrganizationImpl(final IRI iri) {
         super(KindOfOrganizationImpl.class, iri, KIND_OF_ORGANIZATION);
     }
 
     /**
-     * Builder for KindOfOrganizationImpl.
+     * Builder for constructing instances of KindOfOrganization.
      */
     public static class Builder {
-        /** */
+
         private final KindOfOrganizationImpl kindOfOrganizationImpl;
 
         /**
+         * Constructs a Builder for a new KindOfOrganization.
          *
-         * @param iri
+         * @param iri IRI of the KindOfOrganization.
          */
         public Builder(final IRI iri) {
             kindOfOrganizationImpl = new KindOfOrganizationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,13 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.KindOfSystem}
+         * has a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link uk.gov.gchq.hqdm.model.KindOfSystemComponent} as a component.
          *
-         * @param kindOfOrganizationComponent
-         * @return
+         * @param kindOfOrganizationComponent The KindOfOrganizationComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfOrganizationComponent kindOfOrganizationComponent) {
@@ -85,9 +95,11 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfOrganizationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -95,9 +107,11 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfOrganizationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -105,9 +119,11 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfOrganizationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -115,9 +131,12 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -127,9 +146,12 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -139,9 +161,11 @@ public class KindOfOrganizationImpl extends HqdmObject implements KindOfOrganiza
         }
 
         /**
+         * Returns an instance of KindOfOrganization created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfOrganization.
+         * @throws HqdmException If the KindOfOrganization is missing any mandatory properties.
          */
         public KindOfOrganization build() throws HqdmException {
             if (!kindOfOrganizationImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPartyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPartyImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
     /**
+     * Constructs a new KindOfParty.
      *
-     * @param iri
+     * @param iri IRI of the KindOfParty.
      */
     public KindOfPartyImpl(final IRI iri) {
         super(KindOfPartyImpl.class, iri, KIND_OF_PARTY);
     }
 
     /**
-     * Builder for KindOfPartyImpl.
+     * Builder for constructing instances of KindOfParty.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPartyImpl kindOfPartyImpl;
 
         /**
+         * Constructs a Builder for a new KindOfParty.
          *
-         * @param iri
+         * @param iri IRI of the KindOfParty.
          */
         public Builder(final IRI iri) {
             kindOfPartyImpl = new KindOfPartyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,13 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.KindOfSystem}
+         * has a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfSystemComponent} as a component.
          *
-         * @param kindOfSystemComponent
-         * @return
+         * @param kindOfSystemComponent The KindOfSystemComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfSystemComponent kindOfSystemComponent) {
@@ -83,9 +93,11 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPartyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -93,9 +105,11 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPartyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -103,9 +117,11 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPartyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -113,9 +129,12 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -124,9 +143,12 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -135,9 +157,10 @@ public class KindOfPartyImpl extends HqdmObject implements KindOfParty {
         }
 
         /**
+         * Returns an instance of KindOfParty created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfParty.
+         * @throws HqdmException If the KindOfParty is missing any mandatory properties.
          */
         public KindOfParty build() throws HqdmException {
             if (!kindOfPartyImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPersonImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPersonImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
     /**
+     * Constructs a new KindOfPerson.
      *
-     * @param iri
+     * @param iri IRI of the KindOfPerson.
      */
     public KindOfPersonImpl(final IRI iri) {
         super(KindOfPersonImpl.class, iri, KIND_OF_PERSON);
     }
 
     /**
-     * Builder for KindOfPersonImpl.
+     * Builder for constructing instances of KindOfPerson.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPersonImpl kindOfPersonImpl;
 
         /**
+         * Constructs a Builder for a new KindOfPerson.
          *
-         * @param iri
+         * @param iri IRI of the KindOfPerson.
          */
         public Builder(final IRI iri) {
             kindOfPersonImpl = new KindOfPersonImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,13 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link uk.gov.gchq.hqdm.model.KindOfSystem}
+         * has a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfSystemComponent} as a component.
          *
-         * @param kindOfSystemComponent
-         * @return
+         * @param kindOfSystemComponent The KindOfSystemComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfSystemComponent kindOfSystemComponent) {
@@ -83,9 +93,11 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPersonImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -93,9 +105,11 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPersonImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -103,9 +117,11 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPersonImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -113,9 +129,12 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -124,9 +143,12 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -135,9 +157,10 @@ public class KindOfPersonImpl extends HqdmObject implements KindOfPerson {
         }
 
         /**
+         * Returns an instance of KindOfPerson created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfPerson.
+         * @throws HqdmException If the KindOfPerson is missing any mandatory properties.
          */
         public KindOfPerson build() throws HqdmException {
             if (!kindOfPersonImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalObjectImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysicalObject {
     /**
+     * Constructs a new KindOfPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfPhysicalObject.
      */
     public KindOfPhysicalObjectImpl(final IRI iri) {
         super(KindOfPhysicalObjectImpl.class, iri, KIND_OF_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for KindOfPhysicalObjectImpl.
+     * Builder for constructing instances of KindOfPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPhysicalObjectImpl kindOfPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfPhysicalObject.
          */
         public Builder(final IRI iri) {
             kindOfPhysicalObjectImpl = new KindOfPhysicalObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPhysicalObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPhysicalObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class KindOfPhysicalObjectImpl extends HqdmObject implements KindOfPhysic
         }
 
         /**
+         * Returns an instance of KindOfPhysicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfPhysicalObject.
+         * @throws HqdmException If the KindOfPhysicalObject is missing any mandatory properties.
          */
         public KindOfPhysicalObject build() throws HqdmException {
             if (kindOfPhysicalObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalPropertyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalPropertyImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPhysicalPropertyImpl extends HqdmObject implements KindOfPhysicalProperty {
     /**
+     * Constructs a new KindOfPhysicalProperty.
      *
-     * @param iri
+     * @param iri IRI of the KindOfPhysicalProperty.
      */
     public KindOfPhysicalPropertyImpl(final IRI iri) {
         super(KindOfPhysicalPropertyImpl.class, iri, KIND_OF_PHYSICAL_PROPERTY);
     }
 
     /**
-     * Builder for KindOfPhysicalPropertyImpl.
+     * Builder for constructing instances of KindOfPhysicalProperty.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPhysicalPropertyImpl kindOfPhysicalPropertyImpl;
 
         /**
+         * Constructs a Builder for a new KindOfPhysicalProperty.
          *
-         * @param iri
+         * @param iri IRI of the KindOfPhysicalProperty.
          */
         public Builder(final IRI iri) {
             kindOfPhysicalPropertyImpl = new KindOfPhysicalPropertyImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPhysicalPropertyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class KindOfPhysicalPropertyImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPhysicalPropertyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class KindOfPhysicalPropertyImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPhysicalPropertyImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class KindOfPhysicalPropertyImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * Returns an instance of KindOfPhysicalProperty created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfPhysicalProperty.
+         * @throws HqdmException If the KindOfPhysicalProperty is missing any mandatory properties.
          */
         public KindOfPhysicalProperty build() throws HqdmException {
             if (kindOfPhysicalPropertyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalQuantityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPhysicalQuantityImpl.java
@@ -31,32 +31,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPhysicalQuantityImpl extends HqdmObject implements KindOfPhysicalQuantity {
     /**
+     * Constructs a new KindOfPhysicalQuantity.
      *
-     * @param iri
+     * @param iri IRI of the KindOfPhysicalQuantity.
      */
     public KindOfPhysicalQuantityImpl(final IRI iri) {
         super(KindOfPhysicalQuantityImpl.class, iri, KIND_OF_PHYSICAL_QUANTITY);
     }
 
     /**
-     * Builder for KindOfPhysicalQuantityImpl.
+     * Builder for constructing instances of KindOfPhysicalQuantity.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPhysicalQuantityImpl kindOfPhysicalQuantityImpl;
 
         /**
+         * Constructs a Builder for a new KindOfPhysicalQuantity.
          *
-         * @param iri
+         * @param iri IRI of the KindOfPhysicalQuantity.
          */
         public Builder(final IRI iri) {
             kindOfPhysicalQuantityImpl = new KindOfPhysicalQuantityImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPhysicalQuantityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -64,9 +68,11 @@ public class KindOfPhysicalQuantityImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPhysicalQuantityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -74,9 +80,11 @@ public class KindOfPhysicalQuantityImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPhysicalQuantityImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -84,9 +92,11 @@ public class KindOfPhysicalQuantityImpl extends HqdmObject implements KindOfPhys
         }
 
         /**
+         * Returns an instance of KindOfPhysicalQuantity created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfPhysicalQuantity.
+         * @throws HqdmException If the KindOfPhysicalQuantity is missing any mandatory properties.
          */
         public KindOfPhysicalQuantity build() throws HqdmException {
             if (kindOfPhysicalQuantityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfPositionImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
     /**
+     * Constructs a new KindOfPosition.
      *
-     * @param iri
+     * @param iri IRI of the KindOfPosition.
      */
     public KindOfPositionImpl(final IRI iri) {
         super(KindOfPositionImpl.class, iri, KIND_OF_POSITION);
     }
 
     /**
-     * Builder for KindOfPositionImpl.
+     * Builder for constructing instances of KindOfPosition.
      */
     public static class Builder {
-        /** */
+
         private final KindOfPositionImpl kindOfPositionImpl;
 
         /**
+         * Constructs a Builder for a new KindOfPosition.
          *
-         * @param iri
+         * @param iri IRI of the KindOfPosition.
          */
         public Builder(final IRI iri) {
             kindOfPositionImpl = new KindOfPositionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfPositionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfPositionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -112,9 +127,12 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -123,9 +141,10 @@ public class KindOfPositionImpl extends HqdmObject implements KindOfPosition {
         }
 
         /**
+         * Returns an instance of KindOfPosition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfPosition.
+         * @throws HqdmException If the KindOfPosition is missing any mandatory properties.
          */
         public KindOfPosition build() throws HqdmException {
             if (kindOfPositionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfRelationshipWithRestrictionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfRelationshipWithRestrictionImpl.java
@@ -35,8 +35,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
         implements KindOfRelationshipWithRestriction {
     /**
+     * Constructs a new KindOfRelationshipWithRestriction.
      *
-     * @param iri
+     * @param iri IRI of the KindOfRelationshipWithRestriction.
      */
     public KindOfRelationshipWithRestrictionImpl(final IRI iri) {
         super(KindOfRelationshipWithRestrictionImpl.class, iri,
@@ -44,24 +45,27 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
     }
 
     /**
-     * Builder for KindOfRelationshipWithRestrictionImpl.
+     * Builder for constructing instances of KindOfRelationshipWithRestriction.
      */
     public static class Builder {
-        /** */
+
         private final KindOfRelationshipWithRestrictionImpl kindOfRelationshipWithRestrictionImpl;
 
         /**
+         * Constructs a Builder for a new KindOfRelationshipWithRestriction.
          *
-         * @param iri
+         * @param iri IRI of the KindOfRelationshipWithRestriction.
          */
         public Builder(final IRI iri) {
             kindOfRelationshipWithRestrictionImpl = new KindOfRelationshipWithRestrictionImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfRelationshipWithRestrictionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -69,9 +73,11 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfRelationshipWithRestrictionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -79,9 +85,11 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfRelationshipWithRestrictionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -90,10 +98,10 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
 
         /**
          * A relationship type where the {@link Classification} is of a required role player for the
-         * members of a kind_of_relationship_with_restriction.
+         * members of a {@link KindOfRelationshipWithRestriction}.
          *
-         * @param classification
-         * @return
+         * @param classification The Classification.
+         * @return This builder.
          */
         public final Builder required_Role_Player_M(final Classification classification) {
             kindOfRelationshipWithRestrictionImpl.addValue(REQUIRED_ROLE_PLAYER,
@@ -102,9 +110,11 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
         }
 
         /**
+         * The roles that must be filled by members of a
+         * {@link uk.gov.gchq.hqdm.model.KindOfRelationshipWithSignature}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder roles_M(final Class clazz) {
             kindOfRelationshipWithRestrictionImpl.addValue(ROLES, clazz.getIri());
@@ -112,9 +122,12 @@ public class KindOfRelationshipWithRestrictionImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfRelationshipWithRestriction created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfRelationshipWithRestriction.
+         * @throws HqdmException If the KindOfRelationshipWithRestriction is missing any mandatory
+         *         properties.
          */
         public KindOfRelationshipWithRestriction build() throws HqdmException {
             if (kindOfRelationshipWithRestrictionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfRelationshipWithSignatureImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfRelationshipWithSignatureImpl.java
@@ -33,32 +33,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfRelationshipWithSignatureImpl extends HqdmObject
         implements KindOfRelationshipWithSignature {
     /**
+     * Constructs a new KindOfRelationshipWithSignature.
      *
-     * @param iri
+     * @param iri IRI of the KindOfRelationshipWithSignature.
      */
     public KindOfRelationshipWithSignatureImpl(final IRI iri) {
         super(KindOfRelationshipWithSignatureImpl.class, iri, KIND_OF_RELATIONSHIP_WITH_SIGNATURE);
     }
 
     /**
-     * Builder for KindOfRelationshipWithSignatureImpl.
+     * Builder for constructing instances of KindOfRelationshipWithSignature.
      */
     public static class Builder {
-        /** */
+
         private final KindOfRelationshipWithSignatureImpl kindOfRelationshipWithSignatureImpl;
 
         /**
+         * Constructs a Builder for a new KindOfRelationshipWithSignature.
          *
-         * @param iri
+         * @param iri IRI of the KindOfRelationshipWithSignature.
          */
         public Builder(final IRI iri) {
             kindOfRelationshipWithSignatureImpl = new KindOfRelationshipWithSignatureImpl(iri);
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfRelationshipWithSignatureImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -66,9 +70,11 @@ public class KindOfRelationshipWithSignatureImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfRelationshipWithSignatureImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -76,9 +82,11 @@ public class KindOfRelationshipWithSignatureImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfRelationshipWithSignatureImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -86,10 +94,10 @@ public class KindOfRelationshipWithSignatureImpl extends HqdmObject
         }
 
         /**
-         * The roles that must be filled by members of a kind_of_relationship_with_signature.
+         * The roles that must be filled by members of a {@link KindOfRelationshipWithSignature}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder roles_M(final Class clazz) {
             kindOfRelationshipWithSignatureImpl.addValue(ROLES, clazz.getIri());
@@ -97,9 +105,12 @@ public class KindOfRelationshipWithSignatureImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfRelationshipWithSignature created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfRelationshipWithSignature.
+         * @throws HqdmException If the KindOfRelationshipWithSignature is missing any mandatory
+         *         properties.
          */
         public KindOfRelationshipWithSignature build() throws HqdmException {
             if (kindOfRelationshipWithSignatureImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSociallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSociallyConstructedObjectImpl.java
@@ -37,32 +37,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         implements KindOfSociallyConstructedObject {
     /**
+     * Constructs a new KindOfSociallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the KindOfSociallyConstructedObject.
      */
     public KindOfSociallyConstructedObjectImpl(final IRI iri) {
         super(KindOfSociallyConstructedObjectImpl.class, iri, KIND_OF_SOCIALLY_CONSTRUCTED_OBJECT);
     }
 
     /**
-     * Builder for KindOfSociallyConstructedObjectImpl.
+     * Builder for constructing instances of KindOfSociallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         private final KindOfSociallyConstructedObjectImpl kindOfSociallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new KindOfSociallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the KindOfSociallyConstructedObject.
          */
         public Builder(final IRI iri) {
             kindOfSociallyConstructedObjectImpl = new KindOfSociallyConstructedObjectImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,9 +78,11 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfSociallyConstructedObjectImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -82,9 +90,11 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfSociallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -92,9 +102,11 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfSociallyConstructedObjectImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -102,9 +114,12 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -114,9 +129,12 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,9 +144,12 @@ public class KindOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of KindOfSociallyConstructedObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfSociallyConstructedObject.
+         * @throws HqdmException If the KindOfSociallyConstructedObject is missing any mandatory
+         *         properties.
          */
         public KindOfSociallyConstructedObject build() throws HqdmException {
             if (kindOfSociallyConstructedObjectImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSystemComponentImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSystemComponent {
     /**
+     * Constructs a new KindOfSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the KindOfSystemComponent.
      */
     public KindOfSystemComponentImpl(final IRI iri) {
         super(KindOfSystemComponentImpl.class, iri, KIND_OF_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for KindOfSystemComponentImpl.
+     * Builder for constructing instances of KindOfSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final KindOfSystemComponentImpl kindOfSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new KindOfSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the KindOfSystemComponent.
          */
         public Builder(final IRI iri) {
             kindOfSystemComponentImpl = new KindOfSystemComponentImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -71,9 +77,11 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfSystemComponentImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -81,9 +89,11 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -91,9 +101,11 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfSystemComponentImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -101,9 +113,12 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -113,9 +128,12 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -125,9 +143,11 @@ public class KindOfSystemComponentImpl extends HqdmObject implements KindOfSyste
         }
 
         /**
+         * Returns an instance of KindOfSystemComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfSystemComponent.
+         * @throws HqdmException If the KindOfSystemComponent is missing any mandatory properties.
          */
         public KindOfSystemComponent build() throws HqdmException {
             if (kindOfSystemComponentImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/KindOfSystemImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
     /**
+     * Constructs a new KindOfSystem.
      *
-     * @param iri
+     * @param iri IRI of the KindOfSystem.
      */
     public KindOfSystemImpl(final IRI iri) {
         super(KindOfSystemImpl.class, iri, KIND_OF_SYSTEM);
     }
 
     /**
-     * Builder for KindOfSystemImpl.
+     * Builder for constructing instances of KindOfSystem.
      */
     public static class Builder {
-        /** */
+
         private final KindOfSystemImpl kindOfSystemImpl;
 
         /**
+         * Constructs a Builder for a new KindOfSystem.
          *
-         * @param iri
+         * @param iri IRI of the KindOfSystem.
          */
         public Builder(final IRI iri) {
             kindOfSystemImpl = new KindOfSystemImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -72,11 +78,13 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
-         * A consists_of_by_class relationship type where each member_of a kind_of_system has a
-         * member_of one or more {@link KindOfSystemComponent} as a component.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link KindOfSystem} has a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfSystemComponent} as
+         * a component.
          *
-         * @param kindOfSystemComponent
-         * @return
+         * @param kindOfSystemComponent The KindOfSystemComponent.
+         * @return This builder.
          */
         public final Builder has_Component_By_Class_M(
                 final KindOfSystemComponent kindOfSystemComponent) {
@@ -85,9 +93,11 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             kindOfSystemImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -95,9 +105,11 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             kindOfSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -105,9 +117,11 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             kindOfSystemImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -115,9 +129,12 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -126,9 +143,12 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -137,9 +157,10 @@ public class KindOfSystemImpl extends HqdmObject implements KindOfSystem {
         }
 
         /**
+         * Returns an instance of KindOfSystem created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built KindOfSystem.
+         * @throws HqdmException If the KindOfSystem is missing any mandatory properties.
          */
         public KindOfSystem build() throws HqdmException {
             if (!kindOfSystemImpl.hasValue(HAS_COMPONENT_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/LanguageCommunityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/LanguageCommunityImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class LanguageCommunityImpl extends HqdmObject implements LanguageCommunity {
     /**
+     * Constructs a new LanguageCommunity.
      *
-     * @param iri
+     * @param iri IRI of the LanguageCommunity.
      */
     public LanguageCommunityImpl(final IRI iri) {
         super(LanguageCommunityImpl.class, iri, LANGUAGE_COMMUNITY);
     }
 
     /**
-     * Builder for LanguageCommunityImpl.
+     * Builder for constructing instances of LanguageCommunity.
      */
     public static class Builder {
-        /** */
+
         private final LanguageCommunityImpl languageCommunityImpl;
 
         /**
+         * Constructs a Builder for a new LanguageCommunity.
          *
-         * @param iri
+         * @param iri IRI of the LanguageCommunity.
          */
         public Builder(final IRI iri) {
             languageCommunityImpl = new LanguageCommunityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             languageCommunityImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             languageCommunityImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             languageCommunityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             languageCommunityImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             languageCommunityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,9 +136,13 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganization} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrganization}.
          *
-         * @param classOfStateOfOrganization
-         * @return
+         * @param classOfStateOfOrganization The ClassOfStateOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrganization classOfStateOfOrganization) {
@@ -127,9 +151,12 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where
+         * {@link uk.gov.gchq.hqdm.model.Organization} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfOrganization}.
          *
-         * @param kindOfOrganization
-         * @return
+         * @param kindOfOrganization The KindOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfOrganization kindOfOrganization) {
             languageCommunityImpl.addValue(MEMBER_OF_KIND, kindOfOrganization.getIri());
@@ -137,9 +164,12 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             languageCommunityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -147,9 +177,17 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             languageCommunityImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -157,9 +195,12 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             languageCommunityImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -167,9 +208,12 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfLanguageCommunity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link LanguageCommunity}.
          *
-         * @param languageCommunity
-         * @return
+         * @param languageCommunity The LanguageCommunity.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final LanguageCommunity languageCommunity) {
             languageCommunityImpl.addValue(TEMPORAL_PART_OF, languageCommunity.getIri());
@@ -177,9 +221,10 @@ public class LanguageCommunityImpl extends HqdmObject implements LanguageCommuni
         }
 
         /**
+         * Returns an instance of LanguageCommunity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built LanguageCommunity.
+         * @throws HqdmException If the LanguageCommunity is missing any mandatory properties.
          */
         public LanguageCommunity build() throws HqdmException {
             if (languageCommunityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/MoneyAssetImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/MoneyAssetImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
     /**
+     * Constructs a new MoneyAsset.
      *
-     * @param iri
+     * @param iri IRI of the MoneyAsset.
      */
     public MoneyAssetImpl(final IRI iri) {
         super(MoneyAssetImpl.class, iri, MONEY_ASSET);
     }
 
     /**
-     * Builder for MoneyAssetImpl.
+     * Builder for constructing instances of MoneyAsset.
      */
     public static class Builder {
-        /** */
+
         private final MoneyAssetImpl moneyAssetImpl;
 
         /**
+         * Constructs a Builder for a new MoneyAsset.
          *
-         * @param iri
+         * @param iri IRI of the MoneyAsset.
          */
         public Builder(final IRI iri) {
             moneyAssetImpl = new MoneyAssetImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             moneyAssetImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             moneyAssetImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             moneyAssetImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             moneyAssetImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             moneyAssetImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.Participant} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfParticipant}.
          *
-         * @param classOfParticipant
-         * @return
+         * @param classOfParticipant The ClassOfParticipant.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfParticipant classOfParticipant) {
             moneyAssetImpl.addValue(MEMBER_OF, classOfParticipant.getIri());
@@ -129,9 +152,12 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             moneyAssetImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             moneyAssetImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             moneyAssetImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,9 +196,11 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where an asset is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} exactly one {@link Ownership}.
          *
-         * @param ownership
-         * @return
+         * @param ownership The Ownership.
+         * @return This builder.
          */
         public final Builder participant_In_M(final Ownership ownership) {
             moneyAssetImpl.addValue(PARTICIPANT_IN, ownership.getIri());
@@ -169,9 +208,12 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             moneyAssetImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -179,9 +221,12 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link PhysicalObject}.
          *
-         * @param physicalObject
-         * @return
+         * @param physicalObject The PhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final PhysicalObject physicalObject) {
             moneyAssetImpl.addValue(TEMPORAL_PART_OF, physicalObject.getIri());
@@ -189,9 +234,10 @@ public class MoneyAssetImpl extends HqdmObject implements MoneyAsset {
         }
 
         /**
+         * Returns an instance of MoneyAsset created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built MoneyAsset.
+         * @throws HqdmException If the MoneyAsset is missing any mandatory properties.
          */
         public MoneyAsset build() throws HqdmException {
             if (moneyAssetImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferAndAcceptanceForGoodsImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferAndAcceptanceForGoodsImpl.java
@@ -59,32 +59,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         implements OfferAndAcceptanceForGoods {
     /**
+     * Constructs a new OfferAndAcceptanceForGoods.
      *
-     * @param iri
+     * @param iri IRI of the OfferAndAcceptanceForGoods.
      */
     public OfferAndAcceptanceForGoodsImpl(final IRI iri) {
         super(OfferAndAcceptanceForGoodsImpl.class, iri, OFFER_AND_ACCEPTANCE_FOR_GOODS);
     }
 
     /**
-     * Builder for OfferAndAcceptanceForGoodsImpl.
+     * Builder for constructing instances of OfferAndAcceptanceForGoods.
      */
     public static class Builder {
-        /** */
+
         private final OfferAndAcceptanceForGoodsImpl offerAndAcceptanceForGoodsImpl;
 
         /**
+         * Constructs a Builder for a new OfferAndAcceptanceForGoods.
          *
-         * @param iri
+         * @param iri IRI of the OfferAndAcceptanceForGoods.
          */
         public Builder(final IRI iri) {
             offerAndAcceptanceForGoodsImpl = new OfferAndAcceptanceForGoodsImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             offerAndAcceptanceForGoodsImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -92,9 +100,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             offerAndAcceptanceForGoodsImpl.addValue(BEGINNING, event.getIri());
@@ -102,9 +112,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             offerAndAcceptanceForGoodsImpl.addValue(CAUSES, event.getIri());
@@ -112,9 +124,15 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerAndAcceptanceForGoodsImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -122,11 +140,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
-         * A consists_of relationship type where an offer_and_acceptance_for_goods consists of
-         * exactly one {@link AcceptanceOfOfferForGoods}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link OfferAndAcceptanceForGoods} consists of exactly one
+         * {@link AcceptanceOfOfferForGoods}.
          *
-         * @param acceptanceOfOfferForGoods
-         * @return
+         * @param acceptanceOfOfferForGoods The AcceptanceOfOfferForGoods.
+         * @return Builder
          */
         public final Builder consists_Of(
                 final AcceptanceOfOfferForGoods acceptanceOfOfferForGoods) {
@@ -136,11 +155,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
-         * A consists_of_ relationship type where an offer_and_acceptance_for_goods consists_of
-         * exactly one {@link OfferForGoods}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_} relationship type where an
+         * {@link OfferAndAcceptanceForGoods} consists_of exactly one {@link OfferForGoods}.
          *
-         * @param offerForGoods
-         * @return
+         * @param offerForGoods The OfferForGoods.
+         * @return Builder
          */
         public final Builder consists_Of_(final OfferForGoods offerForGoods) {
             offerAndAcceptanceForGoodsImpl.addValue(CONSISTS_OF_, offerForGoods.getIri());
@@ -148,9 +167,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             offerAndAcceptanceForGoodsImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -158,9 +180,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             offerAndAcceptanceForGoodsImpl.addValue(DETERMINES, thing.getIri());
@@ -168,9 +192,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             offerAndAcceptanceForGoodsImpl.addValue(ENDING, event.getIri());
@@ -178,9 +204,10 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             offerAndAcceptanceForGoodsImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -188,9 +215,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.AgreeContract} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfAgreeContract}.
          *
-         * @param classOfAgreeContract
-         * @return
+         * @param classOfAgreeContract The ClassOfAgreeContract.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAgreeContract classOfAgreeContract) {
             offerAndAcceptanceForGoodsImpl.addValue(MEMBER_OF, classOfAgreeContract.getIri());
@@ -198,9 +228,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             offerAndAcceptanceForGoodsImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -208,9 +241,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerAndAcceptanceForGoodsImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -218,11 +254,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
-         * A part_of relationship type where an offer_and_acceptance_for_goods is a part_of exactly
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link OfferAndAcceptanceForGoods} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly
          * one {@link SaleOfGoods}.
          *
-         * @param saleOfGoods
-         * @return
+         * @param saleOfGoods The SaleOfGoods.
+         * @return Builder
          */
         public final Builder part_Of_M(final SaleOfGoods saleOfGoods) {
             offerAndAcceptanceForGoodsImpl.addValue(PART_OF, saleOfGoods.getIri());
@@ -230,9 +267,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             offerAndAcceptanceForGoodsImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -240,9 +280,17 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             offerAndAcceptanceForGoodsImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -250,9 +298,11 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             offerAndAcceptanceForGoodsImpl.addValue(REFERENCES, thing.getIri());
@@ -260,9 +310,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerAndAcceptanceForGoodsImpl.addValue(TEMPORAL__PART_OF,
@@ -271,9 +324,21 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             offerAndAcceptanceForGoodsImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -281,9 +346,12 @@ public class OfferAndAcceptanceForGoodsImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of OfferAndAcceptanceForGoods created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OfferAndAcceptanceForGoods.
+         * @throws HqdmException If the OfferAndAcceptanceForGoods is missing any mandatory
+         *         properties.
          */
         public OfferAndAcceptanceForGoods build() throws HqdmException {
             if (offerAndAcceptanceForGoodsImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferForGoodsImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferForGoodsImpl.java
@@ -57,32 +57,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
     /**
+     * Constructs a new OfferForGoods.
      *
-     * @param iri
+     * @param iri IRI of the OfferForGoods.
      */
     public OfferForGoodsImpl(final IRI iri) {
         super(OfferForGoodsImpl.class, iri, OFFER_FOR_GOODS);
     }
 
     /**
-     * Builder for OfferForGoodsImpl.
+     * Builder for constructing instances of OfferForGoods.
      */
     public static class Builder {
-        /** */
+
         private final OfferForGoodsImpl offerForGoodsImpl;
 
         /**
+         * Constructs a Builder for a new OfferForGoods.
          *
-         * @param iri
+         * @param iri IRI of the OfferForGoods.
          */
         public Builder(final IRI iri) {
             offerForGoodsImpl = new OfferForGoodsImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             offerForGoodsImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -90,9 +98,11 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             offerForGoodsImpl.addValue(BEGINNING, event.getIri());
@@ -100,9 +110,11 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             offerForGoodsImpl.addValue(CAUSES, event.getIri());
@@ -110,9 +122,15 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerForGoodsImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -120,9 +138,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             offerForGoodsImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -130,9 +151,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             offerForGoodsImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -140,9 +164,11 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             offerForGoodsImpl.addValue(DETERMINES, thing.getIri());
@@ -150,9 +176,11 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             offerForGoodsImpl.addValue(ENDING, event.getIri());
@@ -160,9 +188,10 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             offerForGoodsImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -170,9 +199,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Offer} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link ClassOfOffer}.
          *
-         * @param classOfOffer
-         * @return
+         * @param classOfOffer The ClassOfOffer.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfOffer classOfOffer) {
             offerForGoodsImpl.addValue(MEMBER_OF, classOfOffer.getIri());
@@ -180,9 +212,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             offerForGoodsImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -190,9 +225,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerForGoodsImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -200,11 +238,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
-         * A part_of relationship type where an offer_for_goods may be part_of no more than one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an
+         * {@link OfferForGoods} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} no more than one
          * {@link OfferAndAcceptanceForGoods}.
          *
-         * @param offerAndAcceptanceForGoods
-         * @return
+         * @param offerAndAcceptanceForGoods The OfferAndAcceptanceForGoods.
+         * @return This builder.
          */
         public final Builder part_Of(final OfferAndAcceptanceForGoods offerAndAcceptanceForGoods) {
             offerForGoodsImpl.addValue(PART_OF, offerAndAcceptanceForGoods.getIri());
@@ -212,9 +251,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             offerForGoodsImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -222,9 +264,17 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             offerForGoodsImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -234,8 +284,8 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         /**
          * A references relationship type to exactly one {@link ExchangeOfGoodsAndMoney} offered.
          *
-         * @param exchangeOfGoodsAndMoney
-         * @return
+         * @param exchangeOfGoodsAndMoney The ExchangeOfGoodsAndMoney.
+         * @return This builder.
          */
         public final Builder references_M(final ExchangeOfGoodsAndMoney exchangeOfGoodsAndMoney) {
             offerForGoodsImpl.addValue(REFERENCES, exchangeOfGoodsAndMoney.getIri());
@@ -243,9 +293,12 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerForGoodsImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -253,9 +306,21 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             offerForGoodsImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -263,9 +328,10 @@ public class OfferForGoodsImpl extends HqdmObject implements OfferForGoods {
         }
 
         /**
+         * Returns an instance of OfferForGoods created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OfferForGoods.
+         * @throws HqdmException If the OfferForGoods is missing any mandatory properties.
          */
         public OfferForGoods build() throws HqdmException {
             if (offerForGoodsImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferImpl.java
@@ -56,32 +56,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OfferImpl extends HqdmObject implements Offer {
     /**
+     * Constructs a new Offer.
      *
-     * @param iri
+     * @param iri IRI of the Offer.
      */
     public OfferImpl(final IRI iri) {
         super(OfferImpl.class, iri, OFFER);
     }
 
     /**
-     * Builder for OfferImpl.
+     * Builder for constructing instances of Offer.
      */
     public static class Builder {
-        /** */
+
         private final OfferImpl offerImpl;
 
         /**
+         * Constructs a Builder for a new Offer.
          *
-         * @param iri
+         * @param iri IRI of the Offer.
          */
         public Builder(final IRI iri) {
             offerImpl = new OfferImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             offerImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -89,9 +97,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             offerImpl.addValue(BEGINNING, event.getIri());
@@ -99,9 +109,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             offerImpl.addValue(CAUSES, event.getIri());
@@ -109,9 +121,15 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -119,9 +137,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             offerImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -129,9 +150,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             offerImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -139,9 +163,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             offerImpl.addValue(DETERMINES, thing.getIri());
@@ -149,9 +175,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             offerImpl.addValue(ENDING, event.getIri());
@@ -159,9 +187,10 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             offerImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -169,11 +198,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
-         * A member_of relationship type where an offer may be a member_of one or more
-         * {@link ClassOfOffer}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an {@link Offer}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfOffer}.
          *
-         * @param classOfOffer
-         * @return
+         * @param classOfOffer The ClassOfOffer.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfOffer classOfOffer) {
             offerImpl.addValue(MEMBER_OF, classOfOffer.getIri());
@@ -181,9 +210,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             offerImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -191,9 +223,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -201,11 +236,11 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
-         * A part_of relationship type where an offer may be part_of at most one
-         * {@link AgreeContract}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where an {@link Offer} may
+         * be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} at most one {@link AgreeContract}.
          *
-         * @param agreeContract
-         * @return
+         * @param agreeContract The AgreeContract.
+         * @return This builder.
          */
         public final Builder part_Of(final AgreeContract agreeContract) {
             offerImpl.addValue(PART_OF, agreeContract.getIri());
@@ -213,9 +248,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             offerImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -223,9 +261,17 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             offerImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -233,9 +279,10 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             offerImpl.addValue(REFERENCES, thing.getIri());
@@ -243,9 +290,12 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             offerImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -253,9 +303,21 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             offerImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -263,9 +325,10 @@ public class OfferImpl extends HqdmObject implements Offer {
         }
 
         /**
+         * Returns an instance of Offer created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Offer.
+         * @throws HqdmException If the Offer is missing any mandatory properties.
          */
         public Offer build() throws HqdmException {
             if (offerImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferingImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OfferingImpl.java
@@ -48,34 +48,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OfferingImpl extends HqdmObject implements Offering {
     /**
+     * Constructs a new Offering.
      *
-     * @param iri
+     * @param iri IRI of the Offering.
      */
     public OfferingImpl(final IRI iri) {
         super(OfferingImpl.class, iri, OFFERING);
     }
 
     /**
-     * Builder for OfferingImpl.
+     * Builder for constructing instances of Offering.
      */
     public static class Builder {
-        /** */
+
         private final OfferingImpl offeringImpl;
 
         /**
+         * Constructs a Builder for a new Offering.
          *
-         * @param iri
+         * @param iri IRI of the Offering.
          */
         public Builder(final IRI iri) {
             offeringImpl = new OfferingImpl(iri);
         }
 
         /**
-         * A relationship type where an offering has exactly one {@link ClassOfIndividual} some
-         * member_of which is offered.
+         * A relationship type where an {@link Offering} has exactly one {@link ClassOfIndividual}
+         * some {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} which is offered.
          *
-         * @param classOfIndividual
-         * @return
+         * @param classOfIndividual The ClassOfIndividual.
+         * @return This builder.
          */
         public final Builder class_Of_Offered_M(final ClassOfIndividual classOfIndividual) {
             offeringImpl.addValue(CLASS_OF_OFFERED, classOfIndividual.getIri());
@@ -83,11 +85,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
-         * A relationship type where an offering has exactly one {@link Price} at which the offering
-         * is made.
+         * A relationship type where an {@link Offering} has exactly one {@link Price} at which the
+         * {@link Offering} is made.
          *
-         * @param price
-         * @return
+         * @param price The Price.
+         * @return This builder.
          */
         public final Builder consideration_By_Class_M(final Price price) {
             offeringImpl.addValue(CONSIDERATION_BY_CLASS, price.getIri());
@@ -95,9 +97,13 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -106,9 +112,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             offeringImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -116,9 +124,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             offeringImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -126,9 +136,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             offeringImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -136,9 +148,12 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -147,11 +162,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
-         * A relationship type where an offering has exactly one {@link Party} who makes the
-         * offering.
+         * A relationship type where an {@link Offering} has exactly one {@link Party} who makes the
+         * {@link Offering}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder offeror_M(final Party party) {
             offeringImpl.addValue(OFFEROR, party.getIri());
@@ -159,9 +174,12 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -170,9 +188,14 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -181,9 +204,14 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -192,10 +220,11 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
-         * A relationship that is exactly one {@link PeriodOfTime} for which the offering is valid.
+         * A relationship that is exactly one {@link PeriodOfTime} for which the {@link Offering} is
+         * valid.
          *
-         * @param periodOfTime
-         * @return
+         * @param periodOfTime The PeriodOfTime.
+         * @return This builder.
          */
         public final Builder period_Offered_M(final PeriodOfTime periodOfTime) {
             offeringImpl.addValue(PERIOD_OFFERED, periodOfTime.getIri());
@@ -203,9 +232,10 @@ public class OfferingImpl extends HqdmObject implements Offering {
         }
 
         /**
+         * Returns an instance of Offering created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Offering.
+         * @throws HqdmException If the Offering is missing any mandatory properties.
          */
         public Offering build() throws HqdmException {
             if (!offeringImpl.hasValue(CLASS_OF_OFFERED)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryBiologicalObjectImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OrdinaryBiologicalObjectImpl extends HqdmObject implements OrdinaryBiologicalObject {
     /**
+     * Constructs a new OrdinaryBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the OrdinaryBiologicalObject.
      */
     public OrdinaryBiologicalObjectImpl(final IRI iri) {
         super(OrdinaryBiologicalObjectImpl.class, iri, ORDINARY_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for OrdinaryBiologicalObjectImpl.
+     * Builder for constructing instances of OrdinaryBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final OrdinaryBiologicalObjectImpl ordinaryBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new OrdinaryBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the OrdinaryBiologicalObject.
          */
         public Builder(final IRI iri) {
             ordinaryBiologicalObjectImpl = new OrdinaryBiologicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryBiologicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             ordinaryBiologicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryBiologicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             ordinaryBiologicalObjectImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             ordinaryBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
-         * A member_of relationship type where an ordinary_biological_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrdinaryBiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfOrdinaryBiologicalObject}.
          *
-         * @param classOfOrdinaryBiologicalObject
-         * @return
+         * @param classOfOrdinaryBiologicalObject The ClassOfOrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfOrdinaryBiologicalObject classOfOrdinaryBiologicalObject) {
@@ -130,11 +151,12 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
-         * A member_of relationship type where an ordinary_biological_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrdinaryBiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link KindOfOrdinaryBiologicalObject}.
          *
-         * @param kindOfOrdinaryBiologicalObject
-         * @return
+         * @param kindOfOrdinaryBiologicalObject The KindOfOrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfOrdinaryBiologicalObject kindOfOrdinaryBiologicalObject) {
@@ -144,9 +166,12 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryBiologicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -154,9 +179,17 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             ordinaryBiologicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -164,9 +197,12 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryBiologicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -174,9 +210,13 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryBiologicalObject}.
          *
-         * @param ordinaryBiologicalObject
-         * @return
+         * @param ordinaryBiologicalObject The OrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final OrdinaryBiologicalObject ordinaryBiologicalObject) {
@@ -186,9 +226,12 @@ public class OrdinaryBiologicalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * Returns an instance of OrdinaryBiologicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OrdinaryBiologicalObject.
+         * @throws HqdmException If the OrdinaryBiologicalObject is missing any mandatory
+         *         properties.
          */
         public OrdinaryBiologicalObject build() throws HqdmException {
             if (ordinaryBiologicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryFunctionalObjectImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OrdinaryFunctionalObjectImpl extends HqdmObject implements OrdinaryFunctionalObject {
     /**
+     * Constructs a new OrdinaryFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the OrdinaryFunctionalObject.
      */
     public OrdinaryFunctionalObjectImpl(final IRI iri) {
         super(OrdinaryFunctionalObjectImpl.class, iri, ORDINARY_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for OrdinaryFunctionalObjectImpl.
+     * Builder for constructing instances of OrdinaryFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final OrdinaryFunctionalObjectImpl ordinaryFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new OrdinaryFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the OrdinaryFunctionalObject.
          */
         public Builder(final IRI iri) {
             ordinaryFunctionalObjectImpl = new OrdinaryFunctionalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryFunctionalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             ordinaryFunctionalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryFunctionalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             ordinaryFunctionalObjectImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.FunctionalObject} has one or
+         * more intended {@link Role}(s).
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_M(final Role role) {
             ordinaryFunctionalObjectImpl.addValue(INTENDED_ROLE, role.getIri());
@@ -119,9 +139,11 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             ordinaryFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -129,11 +151,12 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
-         * A member_of relationship type where an ordinary_functional_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrdinaryFunctionalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfOrdinaryFunctionalObject}.
          *
-         * @param classOfOrdinaryFunctionalObject
-         * @return
+         * @param classOfOrdinaryFunctionalObject The ClassOfOrdinaryFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfOrdinaryFunctionalObject classOfOrdinaryFunctionalObject) {
@@ -143,11 +166,12 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
-         * A member_of relationship type where an ordinary_functional_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrdinaryFunctionalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link KindOfOrdinaryFunctionalObject}.
          *
-         * @param kindOfOrdinaryFunctionalObject
-         * @return
+         * @param kindOfOrdinaryFunctionalObject The KindOfOrdinaryFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfOrdinaryFunctionalObject kindOfOrdinaryFunctionalObject) {
@@ -157,9 +181,12 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryFunctionalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -167,9 +194,17 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             ordinaryFunctionalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -177,9 +212,12 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryFunctionalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -187,9 +225,21 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             ordinaryFunctionalObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -197,9 +247,12 @@ public class OrdinaryFunctionalObjectImpl extends HqdmObject implements Ordinary
         }
 
         /**
+         * Returns an instance of OrdinaryFunctionalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OrdinaryFunctionalObject.
+         * @throws HqdmException If the OrdinaryFunctionalObject is missing any mandatory
+         *         properties.
          */
         public OrdinaryFunctionalObject build() throws HqdmException {
             if (ordinaryFunctionalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OrdinaryPhysicalObjectImpl.java
@@ -44,32 +44,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPhysicalObject {
     /**
+     * Constructs a new OrdinaryPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the OrdinaryPhysicalObject.
      */
     public OrdinaryPhysicalObjectImpl(final IRI iri) {
         super(OrdinaryPhysicalObjectImpl.class, iri, ORDINARY_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for OrdinaryPhysicalObjectImpl.
+     * Builder for constructing instances of OrdinaryPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final OrdinaryPhysicalObjectImpl ordinaryPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new OrdinaryPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the OrdinaryPhysicalObject.
          */
         public Builder(final IRI iri) {
             ordinaryPhysicalObjectImpl = new OrdinaryPhysicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryPhysicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -77,9 +85,11 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             ordinaryPhysicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryPhysicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             ordinaryPhysicalObjectImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             ordinaryPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
-         * A member_of relationship type where an ordinary_physical_object may be a member_of one or
-         * more {@link ClassOfOrdinaryPhysicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrdinaryPhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
+         * or more {@link ClassOfOrdinaryPhysicalObject}.
          *
-         * @param classOfOrdinaryPhysicalObject
-         * @return
+         * @param classOfOrdinaryPhysicalObject The ClassOfOrdinaryPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfOrdinaryPhysicalObject classOfOrdinaryPhysicalObject) {
@@ -130,11 +151,12 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
-         * A member_of_kind relationship type where an ordinary_physical_object may be a member_of
-         * one or more {@link KindOfOrdinaryPhysicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where an
+         * {@link OrdinaryPhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
+         * or more {@link KindOfOrdinaryPhysicalObject}.
          *
-         * @param kindOfOrdinaryPhysicalObject
-         * @return
+         * @param kindOfOrdinaryPhysicalObject The KindOfOrdinaryPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfOrdinaryPhysicalObject kindOfOrdinaryPhysicalObject) {
@@ -144,9 +166,12 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryPhysicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -154,9 +179,17 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             ordinaryPhysicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -164,9 +197,12 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ordinaryPhysicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -174,9 +210,21 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             ordinaryPhysicalObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -184,9 +232,11 @@ public class OrdinaryPhysicalObjectImpl extends HqdmObject implements OrdinaryPh
         }
 
         /**
+         * Returns an instance of OrdinaryPhysicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OrdinaryPhysicalObject.
+         * @throws HqdmException If the OrdinaryPhysicalObject is missing any mandatory properties.
          */
         public OrdinaryPhysicalObject build() throws HqdmException {
             if (ordinaryPhysicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OrganizationComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OrganizationComponentImpl.java
@@ -45,32 +45,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OrganizationComponentImpl extends HqdmObject implements OrganizationComponent {
     /**
+     * Constructs a new OrganizationComponent.
      *
-     * @param iri
+     * @param iri IRI of the OrganizationComponent.
      */
     public OrganizationComponentImpl(final IRI iri) {
         super(OrganizationComponentImpl.class, iri, ORGANIZATION_COMPONENT);
     }
 
     /**
-     * Builder for OrganizationComponentImpl.
+     * Builder for constructing instances of OrganizationComponent.
      */
     public static class Builder {
-        /** */
+
         private final OrganizationComponentImpl organizationComponentImpl;
 
         /**
+         * Constructs a Builder for a new OrganizationComponent.
          *
-         * @param iri
+         * @param iri IRI of the OrganizationComponent.
          */
         public Builder(final IRI iri) {
             organizationComponentImpl = new OrganizationComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -78,9 +86,11 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             organizationComponentImpl.addValue(BEGINNING, event.getIri());
@@ -88,11 +98,12 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
-         * A component_of relationship type where an organization_component is a replaceable
-         * component of exactly one {@link Organization}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#COMPONENT_OF} relationship type where an
+         * {@link OrganizationComponent} is a replaceable component of exactly one
+         * {@link Organization}.
          *
-         * @param organization
-         * @return
+         * @param organization The Organization.
+         * @return This builder.
          */
         public final Builder component_Of_M(final Organization organization) {
             organizationComponentImpl.addValue(COMPONENT_OF, organization.getIri());
@@ -100,9 +111,15 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -110,9 +127,11 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             organizationComponentImpl.addValue(ENDING, event.getIri());
@@ -120,9 +139,11 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             organizationComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -130,11 +151,12 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
-         * A member_of_relationship type where an organization_component may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link OrganizationComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfOrganizationComponent}.
          *
-         * @param classOfOrganizationComponent
-         * @return
+         * @param classOfOrganizationComponent The ClassOfOrganizationComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfOrganizationComponent classOfOrganizationComponent) {
@@ -143,11 +165,12 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
-         * A member_of_kind relationship type where an organization_component may be a member_of one
-         * or more {@link KindOfOrganizationComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where an
+         * {@link OrganizationComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
+         * more {@link KindOfOrganizationComponent}.
          *
-         * @param kindOfOrganizationComponent
-         * @return
+         * @param kindOfOrganizationComponent The KindOfOrganizationComponent.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfOrganizationComponent kindOfOrganizationComponent) {
@@ -157,9 +180,12 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -167,9 +193,17 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             organizationComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -177,9 +211,12 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationComponentImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -187,9 +224,13 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganizationComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrganizationComponent}.
          *
-         * @param organizationComponent
-         * @return
+         * @param organizationComponent The OrganizationComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final OrganizationComponent organizationComponent) {
             organizationComponentImpl.addValue(TEMPORAL_PART_OF, organizationComponent.getIri());
@@ -197,9 +238,11 @@ public class OrganizationComponentImpl extends HqdmObject implements Organizatio
         }
 
         /**
+         * Returns an instance of OrganizationComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built OrganizationComponent.
+         * @throws HqdmException If the OrganizationComponent is missing any mandatory properties.
          */
         public OrganizationComponent build() throws HqdmException {
             if (organizationComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OrganizationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OrganizationImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OrganizationImpl extends HqdmObject implements Organization {
     /**
+     * Constructs a new Organization.
      *
-     * @param iri
+     * @param iri IRI of the Organization.
      */
     public OrganizationImpl(final IRI iri) {
         super(OrganizationImpl.class, iri, ORGANIZATION);
     }
 
     /**
-     * Builder for OrganizationImpl.
+     * Builder for constructing instances of Organization.
      */
     public static class Builder {
-        /** */
+
         private final OrganizationImpl organizationImpl;
 
         /**
+         * Constructs a Builder for a new Organization.
          *
-         * @param iri
+         * @param iri IRI of the Organization.
          */
         public Builder(final IRI iri) {
             organizationImpl = new OrganizationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             organizationImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             organizationImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             organizationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
-         * A member_of relationship type where an organization may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where
+         * {@link Organization} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfOrganization}.
          *
-         * @param classOfOrganization
-         * @return
+         * @param classOfOrganization The ClassOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfOrganization classOfOrganization) {
             organizationImpl.addValue(MEMBER_OF, classOfOrganization.getIri());
@@ -128,11 +149,12 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
-         * A member_of relationship type where an organization may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where
+         * {@link Organization} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfOrganization}.
          *
-         * @param kindOfOrganization
-         * @return
+         * @param kindOfOrganization The KindOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfOrganization kindOfOrganization) {
             organizationImpl.addValue(MEMBER_OF_KIND, kindOfOrganization.getIri());
@@ -140,9 +162,12 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,9 +175,17 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             organizationImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -160,9 +193,12 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             organizationImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -170,9 +206,12 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganization} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Organization}.
          *
-         * @param organization
-         * @return
+         * @param organization The Organization.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Organization organization) {
             organizationImpl.addValue(TEMPORAL_PART_OF, organization.getIri());
@@ -180,9 +219,10 @@ public class OrganizationImpl extends HqdmObject implements Organization {
         }
 
         /**
+         * Returns an instance of Organization created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Organization.
+         * @throws HqdmException If the Organization is missing any mandatory properties.
          */
         public Organization build() throws HqdmException {
             if (organizationImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OwnerImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OwnerImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OwnerImpl extends HqdmObject implements Owner {
     /**
+     * Constructs a new Owner.
      *
-     * @param iri
+     * @param iri IRI of the Owner.
      */
     public OwnerImpl(final IRI iri) {
         super(OwnerImpl.class, iri, OWNER);
     }
 
     /**
-     * Builder for OwnerImpl.
+     * Builder for constructing instances of Owner.
      */
     public static class Builder {
-        /** */
+
         private final OwnerImpl ownerImpl;
 
         /**
+         * Constructs a Builder for a new Owner.
          *
-         * @param iri
+         * @param iri IRI of the Owner.
          */
         public Builder(final IRI iri) {
             ownerImpl = new OwnerImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             ownerImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             ownerImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownerImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             ownerImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             ownerImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfStateOfParty}.
          *
-         * @param classOfStateOfParty
-         * @return
+         * @param classOfStateOfParty The ClassOfStateOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfParty classOfStateOfParty) {
             ownerImpl.addValue(MEMBER_OF, classOfStateOfParty.getIri());
@@ -129,9 +152,12 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             ownerImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownerImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             ownerImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,11 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
-         * A participant_in relationship type where an owner is a participant_in exactly one
-         * {@link Ownership}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where an owner is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} exactly one {@link Ownership}.
          *
-         * @param ownership
-         * @return
+         * @param ownership The Ownership.
+         * @return This builder.
          */
         public final Builder participant_In_M(final Ownership ownership) {
             ownerImpl.addValue(PARTICIPANT_IN, ownership.getIri());
@@ -171,9 +208,12 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownerImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +221,12 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Party}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Party party) {
             ownerImpl.addValue(TEMPORAL_PART_OF, party.getIri());
@@ -191,9 +234,10 @@ public class OwnerImpl extends HqdmObject implements Owner {
         }
 
         /**
+         * Returns an instance of Owner created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Owner.
+         * @throws HqdmException If the Owner is missing any mandatory properties.
          */
         public Owner build() throws HqdmException {
             if (ownerImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/OwnershipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/OwnershipImpl.java
@@ -49,32 +49,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class OwnershipImpl extends HqdmObject implements Ownership {
     /**
+     * Constructs a new Ownership.
      *
-     * @param iri
+     * @param iri IRI of the Ownership.
      */
     public OwnershipImpl(final IRI iri) {
         super(OwnershipImpl.class, iri, OWNERSHIP);
     }
 
     /**
-     * Builder for OwnershipImpl.
+     * Builder for constructing instances of Ownership.
      */
     public static class Builder {
-        /** */
+
         private final OwnershipImpl ownershipImpl;
 
         /**
+         * Constructs a Builder for a new Ownership.
          *
-         * @param iri
+         * @param iri IRI of the Ownership.
          */
         public Builder(final IRI iri) {
             ownershipImpl = new OwnershipImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             ownershipImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -82,11 +90,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
-         * A beginning relationship type where an ownership has as beginning exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#BEGINNING} relationship type where an
+         * {@link Ownership} has as {@link uk.gov.gchq.hqdm.iri.HQDM#BEGINNING} exactly one
          * {@link BeginningOfOwnership}.
          *
-         * @param beginningOfOwnership
-         * @return
+         * @param beginningOfOwnership The BeginningOfOwnership.
+         * @return This builder.
          */
         public final Builder beginning_M(final BeginningOfOwnership beginningOfOwnership) {
             ownershipImpl.addValue(BEGINNING, beginningOfOwnership.getIri());
@@ -94,9 +103,15 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownershipImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -104,11 +119,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
-         * A consists_of_participant relationship type where an ownership consists_of_participant
-         * exactly one {@link Owner}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where an
+         * {@link Ownership} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} exactly one
+         * {@link Owner}.
          *
-         * @param owner
-         * @return
+         * @param owner The Owner.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Owner owner) {
             ownershipImpl.addValue(CONSISTS_OF_PARTICIPANT, owner.getIri());
@@ -116,11 +132,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
-         * A consists_of_participant relationship type where an ownership association
-         * consists_of_participant exactly one {@link Asset}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where an
+         * {@link Ownership} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} exactly one
+         * {@link Asset}.
          *
-         * @param asset
-         * @return
+         * @param asset The Asset.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant_(final Asset asset) {
             ownershipImpl.addValue(CONSISTS_OF_PARTICIPANT_, asset.getIri());
@@ -128,11 +145,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
-         * An ending relationship type where an ownership has as ending not more than one
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#ENDING} relationship type where an {@link Ownership}
+         * has as {@link uk.gov.gchq.hqdm.iri.HQDM#ENDING} not more than one
          * {@link EndingOfOwnership}.
          *
-         * @param endingOfOwnership
-         * @return
+         * @param endingOfOwnership The EndingOfOwnership.
+         * @return This builder.
          */
         public final Builder ending(final EndingOfOwnership endingOfOwnership) {
             ownershipImpl.addValue(ENDING, endingOfOwnership.getIri());
@@ -140,9 +158,11 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             ownershipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -150,9 +170,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Association} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfAssociation}.
          *
-         * @param classOfAssociation
-         * @return
+         * @param classOfAssociation The ClassOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfAssociation classOfAssociation) {
             ownershipImpl.addValue(MEMBER_OF, classOfAssociation.getIri());
@@ -160,9 +183,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Association} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfAssociation}.
          *
-         * @param kindOfAssociation
-         * @return
+         * @param kindOfAssociation The KindOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfAssociation kindOfAssociation) {
             ownershipImpl.addValue(MEMBER_OF_KIND, kindOfAssociation.getIri());
@@ -170,9 +196,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownershipImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -180,9 +209,17 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             ownershipImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -190,9 +227,12 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             ownershipImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -200,9 +240,21 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             ownershipImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -210,9 +262,10 @@ public class OwnershipImpl extends HqdmObject implements Ownership {
         }
 
         /**
+         * Returns an instance of Ownership created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Ownership.
+         * @throws HqdmException If the Ownership is missing any mandatory properties.
          */
         public Ownership build() throws HqdmException {
             if (ownershipImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ParticipantImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ParticipantImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ParticipantImpl extends HqdmObject implements Participant {
     /**
+     * Constructs a new Participant.
      *
-     * @param iri
+     * @param iri IRI of the Participant.
      */
     public ParticipantImpl(final IRI iri) {
         super(ParticipantImpl.class, iri, PARTICIPANT);
     }
 
     /**
-     * Builder for ParticipantImpl.
+     * Builder for constructing instances of Participant.
      */
     public static class Builder {
-        /** */
+
         private final ParticipantImpl participantImpl;
 
         /**
+         * Constructs a Builder for a new Participant.
          *
-         * @param iri
+         * @param iri IRI of the Participant.
          */
         public Builder(final IRI iri) {
             participantImpl = new ParticipantImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             participantImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             participantImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             participantImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             participantImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             participantImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
-         * A member_of relationship type where a participant may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link Participant} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfParticipant}.
          *
-         * @param classOfParticipant
-         * @return
+         * @param classOfParticipant The ClassOfParticipant.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfParticipant classOfParticipant) {
             participantImpl.addValue(MEMBER_OF, classOfParticipant.getIri());
@@ -131,11 +152,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
-         * A member_of_kind relationship type where each participant is a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Participant} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             participantImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -143,9 +165,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             participantImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -153,9 +178,17 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             participantImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -163,9 +196,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A relationship type where a {@link Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} an
+         * {@link uk.gov.gchq.hqdm.model.Association} or {@link uk.gov.gchq.hqdm.model.Activity}.
          *
-         * @param participantInActivityOrAssociation
-         * @return
+         * @param participantInActivityOrAssociation The Participant.nActivityOrAssociation.
+         * @return This builder.
          */
         public final Builder participant_In(
                 final ParticipantInActivityOrAssociation participantInActivityOrAssociation) {
@@ -174,9 +210,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             participantImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -184,9 +223,12 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link PhysicalObject}.
          *
-         * @param physicalObject
-         * @return
+         * @param physicalObject The PhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final PhysicalObject physicalObject) {
             participantImpl.addValue(TEMPORAL_PART_OF, physicalObject.getIri());
@@ -194,9 +236,10 @@ public class ParticipantImpl extends HqdmObject implements Participant {
         }
 
         /**
+         * Returns an instance of Participant created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Participant.
+         * @throws HqdmException If the Participant is missing any mandatory properties.
          */
         public Participant build() throws HqdmException {
             if (participantImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ParticipantInActivityOrAssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ParticipantInActivityOrAssociationImpl.java
@@ -27,8 +27,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class ParticipantInActivityOrAssociationImpl extends HqdmObject
         implements ParticipantInActivityOrAssociation {
     /**
+     * Constructs a new ParticipantInActivityOrAssociation.
      *
-     * @param iri
+     * @param iri IRI of the ParticipantInActivityOrAssociation.
      */
     public ParticipantInActivityOrAssociationImpl(final IRI iri) {
         super(ParticipantInActivityOrAssociationImpl.class, iri,
@@ -36,15 +37,16 @@ public class ParticipantInActivityOrAssociationImpl extends HqdmObject
     }
 
     /**
-     * Builder for ParticipantInActivityOrAssociationImpl.
+     * Builder for constructing instances of ParticipantInActivityOrAssociation.
      */
     public static class Builder {
-        /** */
+
         private final ParticipantInActivityOrAssociationImpl participantInActivityOrAssociationImpl;
 
         /**
+         * Constructs a Builder for a new ParticipantInActivityOrAssociation.
          *
-         * @param iri
+         * @param iri IRI of the ParticipantInActivityOrAssociation.
          */
         public Builder(final IRI iri) {
             participantInActivityOrAssociationImpl =
@@ -52,9 +54,12 @@ public class ParticipantInActivityOrAssociationImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of ParticipantInActivityOrAssociation created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ParticipantInActivityOrAssociation.
+         * @throws HqdmException If the ParticipantInActivityOrAssociation is missing any mandatory
+         *         properties.
          */
         public ParticipantInActivityOrAssociation build() throws HqdmException {
             return participantInActivityOrAssociationImpl;

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PartyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PartyImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PartyImpl extends HqdmObject implements Party {
     /**
+     * Constructs a new Party.
      *
-     * @param iri
+     * @param iri IRI of the Party.
      */
     public PartyImpl(final IRI iri) {
         super(PartyImpl.class, iri, PARTY);
     }
 
     /**
-     * Builder for PartyImpl.
+     * Builder for constructing instances of Party.
      */
     public static class Builder {
-        /** */
+
         private final PartyImpl partyImpl;
 
         /**
+         * Constructs a Builder for a new Party.
          *
-         * @param iri
+         * @param iri IRI of the Party.
          */
         public Builder(final IRI iri) {
             partyImpl = new PartyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             partyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             partyImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             partyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             partyImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             partyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,11 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
-         * A member_of relationship type where a party may be a member_of one or more
-         * {@link ClassOfParty}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Party} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfParty}.
          *
-         * @param classOfParty
-         * @return
+         * @param classOfParty The ClassOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfParty classOfParty) {
             partyImpl.addValue(MEMBER_OF, classOfParty.getIri());
@@ -128,11 +148,12 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
-         * A member_of_kind relationship type where each party may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Party} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfParty}.
          *
-         * @param kindOfParty
-         * @return
+         * @param kindOfParty The KindOfParty.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfParty kindOfParty) {
             partyImpl.addValue(MEMBER_OF_KIND, kindOfParty.getIri());
@@ -140,9 +161,12 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             partyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,9 +174,17 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             partyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -160,9 +192,12 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             partyImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -170,9 +205,12 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Party}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Party party) {
             partyImpl.addValue(TEMPORAL_PART_OF, party.getIri());
@@ -180,9 +218,10 @@ public class PartyImpl extends HqdmObject implements Party {
         }
 
         /**
+         * Returns an instance of Party created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Party.
+         * @throws HqdmException If the Party is missing any mandatory properties.
          */
         public Party build() throws HqdmException {
             if (partyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PatternImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PatternImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PatternImpl extends HqdmObject implements Pattern {
     /**
+     * Constructs a new Pattern.
      *
-     * @param iri
+     * @param iri IRI of the Pattern.
      */
     public PatternImpl(final IRI iri) {
         super(PatternImpl.class, iri, PATTERN);
     }
 
     /**
-     * Builder for PatternImpl.
+     * Builder for constructing instances of Pattern.
      */
     public static class Builder {
-        /** */
+
         private final PatternImpl patternImpl;
 
         /**
+         * Constructs a Builder for a new Pattern.
          *
-         * @param iri
+         * @param iri IRI of the Pattern.
          */
         public Builder(final IRI iri) {
             patternImpl = new PatternImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             patternImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             patternImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             patternImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class PatternImpl extends HqdmObject implements Pattern {
         }
 
         /**
+         * Returns an instance of Pattern created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Pattern.
+         * @throws HqdmException If the Pattern is missing any mandatory properties.
          */
         public Pattern build() throws HqdmException {
             if (patternImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PeriodOfTimeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PeriodOfTimeImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
     /**
+     * Constructs a new PeriodOfTime.
      *
-     * @param iri
+     * @param iri IRI of the PeriodOfTime.
      */
     public PeriodOfTimeImpl(final IRI iri) {
         super(PeriodOfTimeImpl.class, iri, PERIOD_OF_TIME);
     }
 
     /**
-     * Builder for PeriodOfTimeImpl.
+     * Builder for constructing instances of PeriodOfTime.
      */
     public static class Builder {
-        /** */
+
         private final PeriodOfTimeImpl periodOfTimeImpl;
 
         /**
+         * Constructs a Builder for a new PeriodOfTime.
          *
-         * @param iri
+         * @param iri IRI of the PeriodOfTime.
          */
         public Builder(final IRI iri) {
             periodOfTimeImpl = new PeriodOfTimeImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             periodOfTimeImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             periodOfTimeImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             periodOfTimeImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             periodOfTimeImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             periodOfTimeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,12 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
-         * A member_of relationship type where a period_of_time may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PeriodOfTime} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPeriodOfTime}.
          *
-         * @param classOfPeriodOfTime
-         * @return
+         * @param classOfPeriodOfTime The ClassOfPeriodOfTime.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPeriodOfTime classOfPeriodOfTime) {
             periodOfTimeImpl.addValue(MEMBER_OF, classOfPeriodOfTime.getIri());
@@ -128,9 +149,12 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             periodOfTimeImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -138,9 +162,17 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             periodOfTimeImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -148,9 +180,12 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             periodOfTimeImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -158,9 +193,21 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             periodOfTimeImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -168,11 +215,12 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
-         * A temporal_part_of relationship type where a period_of_time may be a temporal_part_of one
-         * or more {@link PossibleWorld}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link PeriodOfTime} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or
+         * more {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of_(final PossibleWorld possibleWorld) {
             periodOfTimeImpl.addValue(TEMPORAL_PART_OF_, possibleWorld.getIri());
@@ -180,9 +228,10 @@ public class PeriodOfTimeImpl extends HqdmObject implements PeriodOfTime {
         }
 
         /**
+         * Returns an instance of PeriodOfTime created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PeriodOfTime.
+         * @throws HqdmException If the PeriodOfTime is missing any mandatory properties.
          */
         public PeriodOfTime build() throws HqdmException {
             if (periodOfTimeImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PersonImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PersonImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PersonImpl extends HqdmObject implements Person {
     /**
+     * Constructs a new Person.
      *
-     * @param iri
+     * @param iri IRI of the Person.
      */
     public PersonImpl(final IRI iri) {
         super(PersonImpl.class, iri, PERSON);
     }
 
     /**
-     * Builder for PersonImpl.
+     * Builder for constructing instances of Person.
      */
     public static class Builder {
-        /** */
+
         private final PersonImpl personImpl;
 
         /**
+         * Constructs a Builder for a new Person.
          *
-         * @param iri
+         * @param iri IRI of the Person.
          */
         public Builder(final IRI iri) {
             personImpl = new PersonImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             personImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             personImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             personImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             personImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,11 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
-         * A member_of relationship type where a person may be a member_of one or more
-         * {@link ClassOfPerson}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Person}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfPerson}.
          *
-         * @param classOfPerson
-         * @return
+         * @param classOfPerson The ClassOfPerson.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPerson classOfPerson) {
             personImpl.addValue(MEMBER_OF, classOfPerson.getIri());
@@ -131,11 +151,12 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
-         * A member_of_kind relationship type where a person may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link Person} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfPerson}.
          *
-         * @param kindOfPerson
-         * @return
+         * @param kindOfPerson The KindOfPerson.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfPerson kindOfPerson) {
             personImpl.addValue(MEMBER_OF_KIND, kindOfPerson.getIri());
@@ -143,9 +164,16 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.BiologicalSystem} has a natural {@link Role} that it plays.
          *
-         * @param role
-         * @return
+         * <p>
+         * Example: My circulatory system has the {@link uk.gov.gchq.hqdm.iri.HQDM#NATURAL_ROLE} of
+         * circulating blood around the body.
+         * </p>
+         *
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder natural_Role_M(final Role role) {
             personImpl.addValue(NATURAL_ROLE, role.getIri());
@@ -153,9 +181,12 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +194,17 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             personImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +212,12 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +225,13 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrdinaryBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryBiologicalObject}.
          *
-         * @param ordinaryBiologicalObject
-         * @return
+         * @param ordinaryBiologicalObject The OrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final OrdinaryBiologicalObject ordinaryBiologicalObject) {
@@ -194,9 +240,10 @@ public class PersonImpl extends HqdmObject implements Person {
         }
 
         /**
+         * Returns an instance of Person created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Person.
+         * @throws HqdmException If the Person is missing any mandatory properties.
          */
         public Person build() throws HqdmException {
             if (personImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PersonInPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PersonInPositionImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PersonInPositionImpl extends HqdmObject implements PersonInPosition {
     /**
+     * Constructs a new PersonInPosition.
      *
-     * @param iri
+     * @param iri IRI of the PersonInPosition.
      */
     public PersonInPositionImpl(final IRI iri) {
         super(PersonInPositionImpl.class, iri, PERSON_IN_POSITION);
     }
 
     /**
-     * Builder for PersonInPositionImpl.
+     * Builder for constructing instances of PersonInPosition.
      */
     public static class Builder {
-        /** */
+
         private final PersonInPositionImpl personInPositionImpl;
 
         /**
+         * Constructs a Builder for a new PersonInPosition.
          *
-         * @param iri
+         * @param iri IRI of the PersonInPosition.
          */
         public Builder(final IRI iri) {
             personInPositionImpl = new PersonInPositionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             personInPositionImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             personInPositionImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personInPositionImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             personInPositionImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             personInPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
-         * A member_of relationship type where a person_in_position may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PersonInPosition} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPersonInPosition}.
          *
-         * @param classOfPersonInPosition
-         * @return
+         * @param classOfPersonInPosition The ClassOfPersonInPosition.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPersonInPosition classOfPersonInPosition) {
             personInPositionImpl.addValue(MEMBER_OF, classOfPersonInPosition.getIri());
@@ -127,9 +148,12 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personInPositionImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             personInPositionImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             personInPositionImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,9 +192,12 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfPosition} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Position}.
          *
-         * @param position
-         * @return
+         * @param position The Position.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Position position) {
             personInPositionImpl.addValue(TEMPORAL_PART_OF, position.getIri());
@@ -167,9 +205,10 @@ public class PersonInPositionImpl extends HqdmObject implements PersonInPosition
         }
 
         /**
+         * Returns an instance of PersonInPosition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PersonInPosition.
+         * @throws HqdmException If the PersonInPosition is missing any mandatory properties.
          */
         public PersonInPosition build() throws HqdmException {
             if (personInPositionImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalObjectImpl.java
@@ -44,32 +44,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
     /**
+     * Constructs a new PhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the PhysicalObject.
      */
     public PhysicalObjectImpl(final IRI iri) {
         super(PhysicalObjectImpl.class, iri, PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for PhysicalObjectImpl.
+     * Builder for constructing instances of PhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final PhysicalObjectImpl physicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new PhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the PhysicalObject.
          */
         public Builder(final IRI iri) {
             physicalObjectImpl = new PhysicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             physicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -77,9 +85,11 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             physicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             physicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             physicalObjectImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             physicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
-         * A member_of relationship type where a physical_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPhysicalObject}.
          *
-         * @param classOfPhysicalObject
-         * @return
+         * @param classOfPhysicalObject The ClassOfPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPhysicalObject classOfPhysicalObject) {
             physicalObjectImpl.addValue(MEMBER_OF, classOfPhysicalObject.getIri());
@@ -129,11 +150,12 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
-         * A member_of relationship type where a physical_object may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfPhysicalObject}.
          *
-         * @param kindOfPhysicalObject
-         * @return
+         * @param kindOfPhysicalObject The KindOfPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfPhysicalObject kindOfPhysicalObject) {
             physicalObjectImpl.addValue(MEMBER_OF_KIND, kindOfPhysicalObject.getIri());
@@ -141,9 +163,12 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             physicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -151,9 +176,17 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             physicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -161,9 +194,12 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             physicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -171,9 +207,21 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             physicalObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -181,9 +229,10 @@ public class PhysicalObjectImpl extends HqdmObject implements PhysicalObject {
         }
 
         /**
+         * Returns an instance of PhysicalObject created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PhysicalObject.
+         * @throws HqdmException If the PhysicalObject is missing any mandatory properties.
          */
         public PhysicalObject build() throws HqdmException {
             if (physicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalPropertyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalPropertyImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty {
     /**
+     * Constructs a new PhysicalProperty.
      *
-     * @param iri
+     * @param iri IRI of the PhysicalProperty.
      */
     public PhysicalPropertyImpl(final IRI iri) {
         super(PhysicalPropertyImpl.class, iri, PHYSICAL_PROPERTY);
     }
 
     /**
-     * Builder for PhysicalPropertyImpl.
+     * Builder for constructing instances of PhysicalProperty.
      */
     public static class Builder {
-        /** */
+
         private final PhysicalPropertyImpl physicalPropertyImpl;
 
         /**
+         * Constructs a Builder for a new PhysicalProperty.
          *
-         * @param iri
+         * @param iri IRI of the PhysicalProperty.
          */
         public Builder(final IRI iri) {
             physicalPropertyImpl = new PhysicalPropertyImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             physicalPropertyImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             physicalPropertyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,11 +103,12 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
-         * A member_of relationship type where a physical_property may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalProperty} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPhysicalProperty}.
          *
-         * @param classOfPhysicalProperty
-         * @return
+         * @param classOfPhysicalProperty The ClassOfPhysicalProperty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPhysicalProperty classOfPhysicalProperty) {
             physicalPropertyImpl.addValue(MEMBER_OF, classOfPhysicalProperty.getIri());
@@ -105,9 +116,12 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -116,11 +130,12 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
-         * A member_of relationship type where a physical_property is a member_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalProperty} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} exactly one
          * {@link KindOfPhysicalProperty}.
          *
-         * @param kindOfPhysicalProperty
-         * @return
+         * @param kindOfPhysicalProperty The KindOfPhysicalProperty.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfPhysicalProperty kindOfPhysicalProperty) {
             physicalPropertyImpl.addValue(MEMBER_OF_KIND, kindOfPhysicalProperty.getIri());
@@ -128,9 +143,12 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -139,9 +157,10 @@ public class PhysicalPropertyImpl extends HqdmObject implements PhysicalProperty
         }
 
         /**
+         * Returns an instance of PhysicalProperty created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PhysicalProperty.
+         * @throws HqdmException If the PhysicalProperty is missing any mandatory properties.
          */
         public PhysicalProperty build() throws HqdmException {
             if (physicalPropertyImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalPropertyRangeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalPropertyRangeImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPropertyRange {
     /**
+     * Constructs a new PhysicalPropertyRange.
      *
-     * @param iri
+     * @param iri IRI of the PhysicalPropertyRange.
      */
     public PhysicalPropertyRangeImpl(final IRI iri) {
         super(PhysicalPropertyRangeImpl.class, iri, PHYSICAL_PROPERTY_RANGE);
     }
 
     /**
-     * Builder for PhysicalPropertyRangeImpl.
+     * Builder for constructing instances of PhysicalPropertyRange.
      */
     public static class Builder {
-        /** */
+
         private final PhysicalPropertyRangeImpl physicalPropertyRangeImpl;
 
         /**
+         * Constructs a Builder for a new PhysicalPropertyRange.
          *
-         * @param iri
+         * @param iri IRI of the PhysicalPropertyRange.
          */
         public Builder(final IRI iri) {
             physicalPropertyRangeImpl = new PhysicalPropertyRangeImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             physicalPropertyRangeImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             physicalPropertyRangeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,9 +103,11 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             physicalPropertyRangeImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -103,9 +115,12 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -128,10 +146,10 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
 
         /**
          * A supertype_of relationship type where the members of each {@link PhysicalProperty} in
-         * the physical_property_range are members of the physical_property_range.
+         * the {@link PhysicalPropertyRange} are members of the {@link PhysicalPropertyRange}.
          *
-         * @param physicalProperty
-         * @return
+         * @param physicalProperty The PhysicalProperty.
+         * @return This builder.
          */
         public final Builder ranges_Over_M(final PhysicalProperty physicalProperty) {
             physicalPropertyRangeImpl.addValue(RANGES_OVER, physicalProperty.getIri());
@@ -139,9 +157,11 @@ public class PhysicalPropertyRangeImpl extends HqdmObject implements PhysicalPro
         }
 
         /**
+         * Returns an instance of PhysicalPropertyRange created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PhysicalPropertyRange.
+         * @throws HqdmException If the PhysicalPropertyRange is missing any mandatory properties.
          */
         public PhysicalPropertyRange build() throws HqdmException {
             if (physicalPropertyRangeImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalQuantityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalQuantityImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity {
     /**
+     * Constructs a new PhysicalQuantity.
      *
-     * @param iri
+     * @param iri IRI of the PhysicalQuantity.
      */
     public PhysicalQuantityImpl(final IRI iri) {
         super(PhysicalQuantityImpl.class, iri, PHYSICAL_QUANTITY);
     }
 
     /**
-     * Builder for PhysicalQuantityImpl.
+     * Builder for constructing instances of PhysicalQuantity.
      */
     public static class Builder {
-        /** */
+
         private final PhysicalQuantityImpl physicalQuantityImpl;
 
         /**
+         * Constructs a Builder for a new PhysicalQuantity.
          *
-         * @param iri
+         * @param iri IRI of the PhysicalQuantity.
          */
         public Builder(final IRI iri) {
             physicalQuantityImpl = new PhysicalQuantityImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             physicalQuantityImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,9 +91,11 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             physicalQuantityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -93,11 +103,12 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
-         * A member_of relationship type where a physical_quantity may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalQuantity} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPhysicalQuantity}.
          *
-         * @param classOfPhysicalQuantity
-         * @return
+         * @param classOfPhysicalQuantity The ClassOfPhysicalQuantity.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPhysicalQuantity classOfPhysicalQuantity) {
             physicalQuantityImpl.addValue(MEMBER_OF, classOfPhysicalQuantity.getIri());
@@ -105,9 +116,12 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -116,11 +130,12 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
-         * A member_of relationship type where a physical_quantity is a member_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PhysicalQuantity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} exactly one
          * {@link KindOfPhysicalQuantity}.
          *
-         * @param kindOfPhysicalQuantity
-         * @return
+         * @param kindOfPhysicalQuantity The KindOfPhysicalQuantity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfPhysicalQuantity kindOfPhysicalQuantity) {
             physicalQuantityImpl.addValue(MEMBER_OF_KIND, kindOfPhysicalQuantity.getIri());
@@ -128,9 +143,12 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -139,9 +157,10 @@ public class PhysicalQuantityImpl extends HqdmObject implements PhysicalQuantity
         }
 
         /**
+         * Returns an instance of PhysicalQuantity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PhysicalQuantity.
+         * @throws HqdmException If the PhysicalQuantity is missing any mandatory properties.
          */
         public PhysicalQuantity build() throws HqdmException {
             if (physicalQuantityImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalQuantityRangeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PhysicalQuantityRangeImpl.java
@@ -41,32 +41,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQuantityRange {
     /**
+     * Constructs a new PhysicalQuantityRange.
      *
-     * @param iri
+     * @param iri IRI of the PhysicalQuantityRange.
      */
     public PhysicalQuantityRangeImpl(final IRI iri) {
         super(PhysicalQuantityRangeImpl.class, iri, PHYSICAL_QUANTITY_RANGE);
     }
 
     /**
-     * Builder for PhysicalQuantityRangeImpl.
+     * Builder for constructing instances of PhysicalQuantityRange.
      */
     public static class Builder {
-        /** */
+
         private final PhysicalQuantityRangeImpl physicalQuantityRangeImpl;
 
         /**
+         * Constructs a Builder for a new PhysicalQuantityRange.
          *
-         * @param iri
+         * @param iri IRI of the PhysicalQuantityRange.
          */
         public Builder(final IRI iri) {
             physicalQuantityRangeImpl = new PhysicalQuantityRangeImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -76,9 +82,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             physicalQuantityRangeImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -86,11 +94,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
-         * A supertype_of relationship type where each physical_quantity_range must have as
-         * lower_bound exactly one {@link PhysicalQuantity}.
+         * A supertype_of relationship type where each {@link PhysicalQuantityRange} must have as
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#LOWER_BOUND} exactly one {@link PhysicalQuantity}.
          *
-         * @param physicalQuantity
-         * @return
+         * @param physicalQuantity The PhysicalQuantity.
+         * @return This builder.
          */
         public final Builder lower_Bound_M(final PhysicalQuantity physicalQuantity) {
             physicalQuantityRangeImpl.addValue(LOWER_BOUND, physicalQuantity.getIri());
@@ -98,9 +106,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             physicalQuantityRangeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -108,9 +118,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             physicalQuantityRangeImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -118,9 +130,12 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -130,9 +145,12 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -142,9 +160,12 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * A supertype_of relationship type where the members of each {@link PhysicalProperty} in
+         * the {@link uk.gov.gchq.hqdm.model.PhysicalPropertyRange} are members of the
+         * {@link uk.gov.gchq.hqdm.model.PhysicalPropertyRange}.
          *
-         * @param physicalProperty
-         * @return
+         * @param physicalProperty The PhysicalProperty.
+         * @return This builder.
          */
         public final Builder ranges_Over_M(final PhysicalProperty physicalProperty) {
             physicalQuantityRangeImpl.addValue(RANGES_OVER, physicalProperty.getIri());
@@ -152,11 +173,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
-         * A supertype_of relationship type where each physical_quantity_range must have as
-         * upper_bound exactly one {@link PhysicalQuantity}.
+         * A supertype_of relationship type where each {@link PhysicalQuantityRange} must have as
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#UPPER_BOUND} exactly one {@link PhysicalQuantity}.
          *
-         * @param physicalQuantity
-         * @return
+         * @param physicalQuantity The PhysicalQuantity.
+         * @return This builder.
          */
         public final Builder upper_Bound_M(final PhysicalQuantity physicalQuantity) {
             physicalQuantityRangeImpl.addValue(UPPER_BOUND, physicalQuantity.getIri());
@@ -164,9 +185,11 @@ public class PhysicalQuantityRangeImpl extends HqdmObject implements PhysicalQua
         }
 
         /**
+         * Returns an instance of PhysicalQuantityRange created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PhysicalQuantityRange.
+         * @throws HqdmException If the PhysicalQuantityRange is missing any mandatory properties.
          */
         public PhysicalQuantityRange build() throws HqdmException {
             if (physicalQuantityRangeImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PlanImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PlanImpl.java
@@ -45,32 +45,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PlanImpl extends HqdmObject implements Plan {
     /**
+     * Constructs a new Plan.
      *
-     * @param iri
+     * @param iri IRI of the Plan.
      */
     public PlanImpl(final IRI iri) {
         super(PlanImpl.class, iri, PLAN);
     }
 
     /**
-     * Builder for PlanImpl.
+     * Builder for constructing instances of Plan.
      */
     public static class Builder {
-        /** */
+
         private final PlanImpl planImpl;
 
         /**
+         * Constructs a Builder for a new Plan.
          *
-         * @param iri
+         * @param iri IRI of the Plan.
          */
         public Builder(final IRI iri) {
             planImpl = new PlanImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             planImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -78,9 +86,11 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             planImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             planImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -98,9 +114,11 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             planImpl.addValue(ENDING, event.getIri());
@@ -108,9 +126,11 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             planImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -118,9 +138,12 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PossibleWorld} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfPossibleWorld}.
          *
-         * @param classOfPossibleWorld
-         * @return
+         * @param classOfPossibleWorld The ClassOfPossibleWorld.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPossibleWorld classOfPossibleWorld) {
             planImpl.addValue(MEMBER_OF, classOfPossibleWorld.getIri());
@@ -128,9 +151,12 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link Individual} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfIndividual}.
          *
-         * @param kindOfIndividual
-         * @return
+         * @param kindOfIndividual The KindOfIndividual.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfIndividual kindOfIndividual) {
             planImpl.addValue(MEMBER_OF_KIND, kindOfIndividual.getIri());
@@ -138,9 +164,12 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             planImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -148,9 +177,17 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             planImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -158,9 +195,12 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             planImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -168,9 +208,21 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             planImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -178,9 +230,12 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.PeriodOfTime} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of_(final PossibleWorld possibleWorld) {
             planImpl.addValue(TEMPORAL_PART_OF_, possibleWorld.getIri());
@@ -188,9 +243,10 @@ public class PlanImpl extends HqdmObject implements Plan {
         }
 
         /**
+         * Returns an instance of Plan created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Plan.
+         * @throws HqdmException If the Plan is missing any mandatory properties.
          */
         public Plan build() throws HqdmException {
             if (planImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PointInTimeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PointInTimeImpl.java
@@ -40,32 +40,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PointInTimeImpl extends HqdmObject implements PointInTime {
     /**
+     * Constructs a new PointInTime.
      *
-     * @param iri
+     * @param iri IRI of the PointInTime.
      */
     public PointInTimeImpl(final IRI iri) {
         super(PointInTimeImpl.class, iri, POINT_IN_TIME);
     }
 
     /**
-     * Builder for PointInTimeImpl.
+     * Builder for constructing instances of PointInTime.
      */
     public static class Builder {
-        /** */
+
         private final PointInTimeImpl pointInTimeImpl;
 
         /**
+         * Constructs a Builder for a new PointInTime.
          *
-         * @param iri
+         * @param iri IRI of the PointInTime.
          */
         public Builder(final IRI iri) {
             pointInTimeImpl = new PointInTimeImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             pointInTimeImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -73,9 +81,11 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             pointInTimeImpl.addValue(BEGINNING, event.getIri());
@@ -83,9 +93,15 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             pointInTimeImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -93,9 +109,11 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             pointInTimeImpl.addValue(ENDING, event.getIri());
@@ -103,9 +121,11 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             pointInTimeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -113,11 +133,12 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
-         * A member_of relationship type where a point_in_time may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PointInTime} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPointInTime}.
          *
-         * @param classOfPointInTime
-         * @return
+         * @param classOfPointInTime The ClassOfPointInTime.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPointInTime classOfPointInTime) {
             pointInTimeImpl.addValue(MEMBER_OF, classOfPointInTime.getIri());
@@ -125,9 +146,12 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             pointInTimeImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -135,9 +159,17 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             pointInTimeImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -145,9 +177,12 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             pointInTimeImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -155,9 +190,10 @@ public class PointInTimeImpl extends HqdmObject implements PointInTime {
         }
 
         /**
+         * Returns an instance of PointInTime created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PointInTime.
+         * @throws HqdmException If the PointInTime is missing any mandatory properties.
          */
         public PointInTime build() throws HqdmException {
             if (pointInTimeImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PositionImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PositionImpl extends HqdmObject implements Position {
     /**
+     * Constructs a new Position.
      *
-     * @param iri
+     * @param iri IRI of the Position.
      */
     public PositionImpl(final IRI iri) {
         super(PositionImpl.class, iri, POSITION);
     }
 
     /**
-     * Builder for PositionImpl.
+     * Builder for constructing instances of Position.
      */
     public static class Builder {
-        /** */
+
         private final PositionImpl positionImpl;
 
         /**
+         * Constructs a Builder for a new Position.
          *
-         * @param iri
+         * @param iri IRI of the Position.
          */
         public Builder(final IRI iri) {
             positionImpl = new PositionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             positionImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             positionImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,11 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#COMPONENT_OF} relationship type where an
+         * {@link OrganizationComponent} is a replaceable component of exactly {@link Organization}.
          *
-         * @param organization
-         * @return
+         * @param organization The Organization.
+         * @return This builder.
          */
         public final Builder component_Of_M(final Organization organization) {
             positionImpl.addValue(COMPONENT_OF, organization.getIri());
@@ -99,9 +111,15 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             positionImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -109,9 +127,11 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             positionImpl.addValue(ENDING, event.getIri());
@@ -119,9 +139,11 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             positionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -129,11 +151,11 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
-         * A member_of relationship type where a position may be a member_of one or more
-         * {@link ClassOfPosition}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Position}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfPosition}.
          *
-         * @param classOfPosition
-         * @return
+         * @param classOfPosition The ClassOfPosition.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPosition classOfPosition) {
             positionImpl.addValue(MEMBER_OF, classOfPosition.getIri());
@@ -141,11 +163,12 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
-         * A member_of_kind relationship type where a position may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link Position} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfPosition}.
          *
-         * @param kindOfPosition
-         * @return
+         * @param kindOfPosition The KindOfPosition.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfPosition kindOfPosition) {
             positionImpl.addValue(MEMBER_OF_KIND, kindOfPosition.getIri());
@@ -153,9 +176,12 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             positionImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +189,17 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             positionImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +207,12 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             positionImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +220,13 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganizationComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrganizationComponent}.
          *
-         * @param organizationComponent
-         * @return
+         * @param organizationComponent The OrganizationComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final OrganizationComponent organizationComponent) {
             positionImpl.addValue(TEMPORAL_PART_OF, organizationComponent.getIri());
@@ -193,9 +234,10 @@ public class PositionImpl extends HqdmObject implements Position {
         }
 
         /**
+         * Returns an instance of Position created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Position.
+         * @throws HqdmException If the Position is missing any mandatory properties.
          */
         public Position build() throws HqdmException {
             if (positionImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PossibleWorldImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PossibleWorldImpl.java
@@ -44,32 +44,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
     /**
+     * Constructs a new PossibleWorld.
      *
-     * @param iri
+     * @param iri IRI of the PossibleWorld.
      */
     public PossibleWorldImpl(final IRI iri) {
         super(PossibleWorldImpl.class, iri, POSSIBLE_WORLD);
     }
 
     /**
-     * Builder for PossibleWorldImpl.
+     * Builder for constructing instances of PossibleWorld.
      */
     public static class Builder {
-        /** */
+
         private final PossibleWorldImpl possibleWorldImpl;
 
         /**
+         * Constructs a Builder for a new PossibleWorld.
          *
-         * @param iri
+         * @param iri IRI of the PossibleWorld.
          */
         public Builder(final IRI iri) {
             possibleWorldImpl = new PossibleWorldImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             possibleWorldImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -77,9 +85,11 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             possibleWorldImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             possibleWorldImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             possibleWorldImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             possibleWorldImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
-         * A member_of relationship type where a possible_world may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link PossibleWorld} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfPossibleWorld}.
          *
-         * @param classOfPossibleWorld
-         * @return
+         * @param classOfPossibleWorld The ClassOfPossibleWorld.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfPossibleWorld classOfPossibleWorld) {
             possibleWorldImpl.addValue(MEMBER_OF, classOfPossibleWorld.getIri());
@@ -129,9 +150,12 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link Individual} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfIndividual}.
          *
-         * @param kindOfIndividual
-         * @return
+         * @param kindOfIndividual The KindOfIndividual.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfIndividual kindOfIndividual) {
             possibleWorldImpl.addValue(MEMBER_OF_KIND, kindOfIndividual.getIri());
@@ -139,9 +163,12 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             possibleWorldImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +176,17 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             possibleWorldImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,9 +194,12 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             possibleWorldImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -169,9 +207,21 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             possibleWorldImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -179,9 +229,12 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.PeriodOfTime} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of_(final PossibleWorld possibleWorld) {
             possibleWorldImpl.addValue(TEMPORAL_PART_OF_, possibleWorld.getIri());
@@ -189,9 +242,10 @@ public class PossibleWorldImpl extends HqdmObject implements PossibleWorld {
         }
 
         /**
+         * Returns an instance of PossibleWorld created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built PossibleWorld.
+         * @throws HqdmException If the PossibleWorld is missing any mandatory properties.
          */
         public PossibleWorld build() throws HqdmException {
             if (possibleWorldImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/PriceImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/PriceImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class PriceImpl extends HqdmObject implements Price {
     /**
+     * Constructs a new Price.
      *
-     * @param iri
+     * @param iri IRI of the Price.
      */
     public PriceImpl(final IRI iri) {
         super(PriceImpl.class, iri, PRICE);
     }
 
     /**
-     * Builder for PriceImpl.
+     * Builder for constructing instances of Price.
      */
     public static class Builder {
-        /** */
+
         private final PriceImpl priceImpl;
 
         /**
+         * Constructs a Builder for a new Price.
          *
-         * @param iri
+         * @param iri IRI of the Price.
          */
         public Builder(final IRI iri) {
             priceImpl = new PriceImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             priceImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             priceImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             priceImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class PriceImpl extends HqdmObject implements Price {
         }
 
         /**
+         * Returns an instance of Price created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Price.
+         * @throws HqdmException If the Price is missing any mandatory properties.
          */
         public Price build() throws HqdmException {
             if (priceImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ProductBrandImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ProductBrandImpl.java
@@ -36,32 +36,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ProductBrandImpl extends HqdmObject implements ProductBrand {
     /**
+     * Constructs a new ProductBrand.
      *
-     * @param iri
+     * @param iri IRI of the ProductBrand.
      */
     public ProductBrandImpl(final IRI iri) {
         super(ProductBrandImpl.class, iri, PRODUCT_BRAND);
     }
 
     /**
-     * Builder for ProductBrandImpl.
+     * Builder for constructing instances of ProductBrand.
      */
     public static class Builder {
-        /** */
+
         private final ProductBrandImpl productBrandImpl;
 
         /**
+         * Constructs a Builder for a new ProductBrand.
          *
-         * @param iri
+         * @param iri IRI of the ProductBrand.
          */
         public Builder(final IRI iri) {
             productBrandImpl = new ProductBrandImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -70,9 +76,11 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             productBrandImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -80,9 +88,11 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             productBrandImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -90,9 +100,11 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             productBrandImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -100,9 +112,12 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -111,9 +126,12 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -122,9 +140,10 @@ public class ProductBrandImpl extends HqdmObject implements ProductBrand {
         }
 
         /**
+         * Returns an instance of ProductBrand created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ProductBrand.
+         * @throws HqdmException If the ProductBrand is missing any mandatory properties.
          */
         public ProductBrand build() throws HqdmException {
             if (productBrandImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ProductOfferingImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ProductOfferingImpl.java
@@ -48,33 +48,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
     /**
+     * Constructs a new ProductOffering.
      *
-     * @param iri
+     * @param iri IRI of the ProductOffering.
      */
     public ProductOfferingImpl(final IRI iri) {
         super(ProductOfferingImpl.class, iri, PRODUCT_OFFERING);
     }
 
     /**
-     * Builder for ProductOfferingImpl.
+     * Builder for constructing instances of ProductOffering.
      */
     public static class Builder {
-        /** */
+
         private final ProductOfferingImpl productOfferingImpl;
 
         /**
+         * Constructs a Builder for a new ProductOffering.
          *
-         * @param iri
+         * @param iri IRI of the ProductOffering.
          */
         public Builder(final IRI iri) {
             productOfferingImpl = new ProductOfferingImpl(iri);
         }
 
         /**
-         * A class_of_offered relationship type where a member_of a {@link SalesProduct} is offered.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CLASS_OF_OFFERED} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link SalesProduct} is offered.
          *
-         * @param salesProduct
-         * @return
+         * @param salesProduct The SalesProduct.
+         * @return This builder.
          */
         public final Builder class_Of_Offered_M(final SalesProduct salesProduct) {
             productOfferingImpl.addValue(CLASS_OF_OFFERED, salesProduct.getIri());
@@ -82,9 +85,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Offering} has exactly one
+         * price at which the {@link uk.gov.gchq.hqdm.model.Offering} is made.
          *
-         * @param price
-         * @return
+         * @param price The Price.
+         * @return This builder.
          */
         public final Builder consideration_By_Class_M(final Price price) {
             productOfferingImpl.addValue(CONSIDERATION_BY_CLASS, price.getIri());
@@ -92,9 +97,13 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -104,9 +113,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             productOfferingImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -114,9 +125,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             productOfferingImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -124,9 +137,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             productOfferingImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -134,9 +149,12 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -145,9 +163,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Offering} has exactly one
+         * {@link Party} who makes the {@link uk.gov.gchq.hqdm.model.Offering}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder offeror_M(final Party party) {
             productOfferingImpl.addValue(OFFEROR, party.getIri());
@@ -155,9 +175,12 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -166,9 +189,14 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(
                 final ClassOfReachingAgreement classOfReachingAgreement) {
@@ -177,9 +205,14 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link uk.gov.gchq.hqdm.model.ClassOfSociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfAgreementExecution}.
          *
-         * @param classOfAgreementExecution
-         * @return
+         * @param classOfAgreementExecution The ClassOfAgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(
                 final ClassOfAgreementExecution classOfAgreementExecution) {
@@ -188,9 +221,11 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * A relationship that is exactly one {@link PeriodOfTime} for which the
+         * {@link uk.gov.gchq.hqdm.model.Offering} is valid.
          *
-         * @param periodOfTime
-         * @return
+         * @param periodOfTime The PeriodOfTime.
+         * @return This builder.
          */
         public final Builder period_Offered_M(final PeriodOfTime periodOfTime) {
             productOfferingImpl.addValue(PERIOD_OFFERED, periodOfTime.getIri());
@@ -198,9 +233,10 @@ public class ProductOfferingImpl extends HqdmObject implements ProductOffering {
         }
 
         /**
+         * Returns an instance of ProductOffering created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ProductOffering.
+         * @throws HqdmException If the ProductOffering is missing any mandatory properties.
          */
         public ProductOffering build() throws HqdmException {
             if (!productOfferingImpl.hasValue(CLASS_OF_OFFERED)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ReachingAgreementImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ReachingAgreementImpl.java
@@ -56,32 +56,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreement {
     /**
+     * Constructs a new ReachingAgreement.
      *
-     * @param iri
+     * @param iri IRI of the ReachingAgreement.
      */
     public ReachingAgreementImpl(final IRI iri) {
         super(ReachingAgreementImpl.class, iri, REACHING_AGREEMENT);
     }
 
     /**
-     * Builder for ReachingAgreementImpl.
+     * Builder for constructing instances of ReachingAgreement.
      */
     public static class Builder {
-        /** */
+
         private final ReachingAgreementImpl reachingAgreementImpl;
 
         /**
+         * Constructs a Builder for a new ReachingAgreement.
          *
-         * @param iri
+         * @param iri IRI of the ReachingAgreement.
          */
         public Builder(final IRI iri) {
             reachingAgreementImpl = new ReachingAgreementImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             reachingAgreementImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -89,9 +97,11 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             reachingAgreementImpl.addValue(BEGINNING, event.getIri());
@@ -99,9 +109,11 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             reachingAgreementImpl.addValue(CAUSES, event.getIri());
@@ -109,9 +121,15 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             reachingAgreementImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -119,9 +137,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             reachingAgreementImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -129,9 +150,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             reachingAgreementImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -139,9 +163,11 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             reachingAgreementImpl.addValue(DETERMINES, thing.getIri());
@@ -149,9 +175,11 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             reachingAgreementImpl.addValue(ENDING, event.getIri());
@@ -159,9 +187,10 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             reachingAgreementImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -169,11 +198,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
-         * A member_of relationship type where a reaching_agreement may be a member_of one or more
-         * {@link ClassOfReachingAgreement}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ReachingAgreement} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
+         * more {@link ClassOfReachingAgreement}.
          *
-         * @param classOfReachingAgreement
-         * @return
+         * @param classOfReachingAgreement The ClassOfReachingAgreement.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfReachingAgreement classOfReachingAgreement) {
             reachingAgreementImpl.addValue(MEMBER_OF, classOfReachingAgreement.getIri());
@@ -181,9 +211,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             reachingAgreementImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -191,9 +224,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             reachingAgreementImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -201,11 +237,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
-         * A part_of relationship type where a reaching_agreement is a part_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link ReachingAgreement} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly one
          * {@link AgreementProcess}.
          *
-         * @param agreementProcess
-         * @return
+         * @param agreementProcess The AgreementProcess.
+         * @return This builder.
          */
         public final Builder part_Of_M(final AgreementProcess agreementProcess) {
             reachingAgreementImpl.addValue(PART_OF, agreementProcess.getIri());
@@ -213,9 +250,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             reachingAgreementImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -223,9 +263,17 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             reachingAgreementImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -233,9 +281,10 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             reachingAgreementImpl.addValue(REFERENCES, thing.getIri());
@@ -243,9 +292,12 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             reachingAgreementImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -253,9 +305,21 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             reachingAgreementImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -263,9 +327,10 @@ public class ReachingAgreementImpl extends HqdmObject implements ReachingAgreeme
         }
 
         /**
+         * Returns an instance of ReachingAgreement created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built ReachingAgreement.
+         * @throws HqdmException If the ReachingAgreement is missing any mandatory properties.
          */
         public ReachingAgreement build() throws HqdmException {
             if (reachingAgreementImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RecognizingLanguageCommunityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RecognizingLanguageCommunityImpl.java
@@ -47,32 +47,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class RecognizingLanguageCommunityImpl extends HqdmObject
         implements RecognizingLanguageCommunity {
     /**
+     * Constructs a new RecognizingLanguageCommunity.
      *
-     * @param iri
+     * @param iri IRI of the RecognizingLanguageCommunity.
      */
     public RecognizingLanguageCommunityImpl(final IRI iri) {
         super(RecognizingLanguageCommunityImpl.class, iri, RECOGNIZING_LANGUAGE_COMMUNITY);
     }
 
     /**
-     * Builder for RecognizingLanguageCommunityImpl.
+     * Builder for constructing instances of RecognizingLanguageCommunity.
      */
     public static class Builder {
-        /** */
+
         private final RecognizingLanguageCommunityImpl recognizingLanguageCommunityImpl;
 
         /**
+         * Constructs a Builder for a new RecognizingLanguageCommunity.
          *
-         * @param iri
+         * @param iri IRI of the RecognizingLanguageCommunity.
          */
         public Builder(final IRI iri) {
             recognizingLanguageCommunityImpl = new RecognizingLanguageCommunityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             recognizingLanguageCommunityImpl.addValue(AGGREGATED_INTO,
@@ -81,9 +89,11 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             recognizingLanguageCommunityImpl.addValue(BEGINNING, event.getIri());
@@ -91,9 +101,15 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             recognizingLanguageCommunityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -101,9 +117,11 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             recognizingLanguageCommunityImpl.addValue(ENDING, event.getIri());
@@ -111,9 +129,11 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             recognizingLanguageCommunityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -121,9 +141,13 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganization} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrganization}.
          *
-         * @param classOfStateOfOrganization
-         * @return
+         * @param classOfStateOfOrganization The ClassOfStateOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrganization classOfStateOfOrganization) {
@@ -133,9 +157,12 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             recognizingLanguageCommunityImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -143,9 +170,12 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             recognizingLanguageCommunityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -153,9 +183,17 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             recognizingLanguageCommunityImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -164,11 +202,13 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
-         * A participant_in relationship type where a recognizing_language_community is a
-         * participant_in one or more {@link RepresentationBySign}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where a
+         * {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} one or more
+         * {@link RepresentationBySign}.
          *
-         * @param representationBySign
-         * @return
+         * @param representationBySign The RepresentationBySign.
+         * @return This builder.
          */
         public final Builder participant_In(final RepresentationBySign representationBySign) {
             recognizingLanguageCommunityImpl.addValue(PARTICIPANT_IN,
@@ -177,9 +217,12 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             recognizingLanguageCommunityImpl.addValue(TEMPORAL__PART_OF,
@@ -188,9 +231,12 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfLanguageCommunity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link LanguageCommunity}.
          *
-         * @param languageCommunity
-         * @return
+         * @param languageCommunity The LanguageCommunity.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final LanguageCommunity languageCommunity) {
             recognizingLanguageCommunityImpl.addValue(TEMPORAL_PART_OF, languageCommunity.getIri());
@@ -198,9 +244,12 @@ public class RecognizingLanguageCommunityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of RecognizingLanguageCommunity created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built RecognizingLanguageCommunity.
+         * @throws HqdmException If the RecognizingLanguageCommunity is missing any mandatory
+         *         properties.
          */
         public RecognizingLanguageCommunity build() throws HqdmException {
             if (recognizingLanguageCommunityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RelationshipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RelationshipImpl.java
@@ -30,32 +30,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RelationshipImpl extends HqdmObject implements Relationship {
     /**
+     * Constructs a new Relationship.
      *
-     * @param iri
+     * @param iri IRI of the Relationship.
      */
     public RelationshipImpl(final IRI iri) {
         super(RelationshipImpl.class, iri, RELATIONSHIP);
     }
 
     /**
-     * Builder for RelationshipImpl.
+     * Builder for constructing instances of Relationship.
      */
     public static class Builder {
-        /** */
+
         private final RelationshipImpl relationshipImpl;
 
         /**
+         * Constructs a Builder for a new Relationship.
          *
-         * @param iri
+         * @param iri IRI of the Relationship.
          */
         public Builder(final IRI iri) {
             relationshipImpl = new RelationshipImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             relationshipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -63,11 +67,11 @@ public class RelationshipImpl extends HqdmObject implements Relationship {
         }
 
         /**
-         * A member_of relationship type where a relationship is a member_of a
-         * {@link ClassOfRelationship}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             relationshipImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -75,9 +79,10 @@ public class RelationshipImpl extends HqdmObject implements Relationship {
         }
 
         /**
+         * Returns an instance of Relationship created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Relationship.
+         * @throws HqdmException If the Relationship is missing any mandatory properties.
          */
         public Relationship build() throws HqdmException {
             if (relationshipImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RepresentationByPatternImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RepresentationByPatternImpl.java
@@ -32,34 +32,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RepresentationByPatternImpl extends HqdmObject implements RepresentationByPattern {
     /**
+     * Constructs a new RepresentationByPattern.
      *
-     * @param iri
+     * @param iri IRI of the RepresentationByPattern.
      */
     public RepresentationByPatternImpl(final IRI iri) {
         super(RepresentationByPatternImpl.class, iri, REPRESENTATION_BY_PATTERN);
     }
 
     /**
-     * Builder for RepresentationByPatternImpl.
+     * Builder for constructing instances of RepresentationByPattern.
      */
     public static class Builder {
-        /** */
+
         private final RepresentationByPatternImpl representationByPatternImpl;
 
         /**
+         * Constructs a Builder for a new RepresentationByPattern.
          *
-         * @param iri
+         * @param iri IRI of the RepresentationByPattern.
          */
         public Builder(final IRI iri) {
             representationByPatternImpl = new RepresentationByPatternImpl(iri);
         }
 
         /**
-         * A consists_of_by_class relationship type where a member_of the representation_by_pattern
-         * has a sign that is a member_of the {@link Pattern}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link RepresentationByPattern} has a
+         * {@link uk.gov.gchq.hqdm.model.Sign} that is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the {@link Pattern}.
          *
-         * @param pattern
-         * @return
+         * @param pattern The Pattern.
+         * @return This builder.
          */
         public final Builder consists_Of_By_Class_M(final Pattern pattern) {
             representationByPatternImpl.addValue(CONSISTS_OF_BY_CLASS, pattern.getIri());
@@ -67,11 +71,12 @@ public class RepresentationByPatternImpl extends HqdmObject implements Represent
         }
 
         /**
-         * A relationship type where a {@link RecognizingLanguageCommunity} is a participant_in each
-         * member_of one or more representation_by_pattern.
+         * A relationship type where a {@link RecognizingLanguageCommunity} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link RepresentationByPattern}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_In_Members_M(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -81,11 +86,11 @@ public class RepresentationByPatternImpl extends HqdmObject implements Represent
         }
 
         /**
-         * A relationship type where the {@link Thing} is represented by each member_of the
-         * representation_by_pattern.
+         * A relationship type where the {@link Thing} is represented by each
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the {@link RepresentationByPattern}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder represented_M(final Thing thing) {
             representationByPatternImpl.addValue(REPRESENTED, thing.getIri());
@@ -93,9 +98,11 @@ public class RepresentationByPatternImpl extends HqdmObject implements Represent
         }
 
         /**
+         * Returns an instance of RepresentationByPattern created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built RepresentationByPattern.
+         * @throws HqdmException If the RepresentationByPattern is missing any mandatory properties.
          */
         public RepresentationByPattern build() throws HqdmException {
             if (!representationByPatternImpl.hasValue(CONSISTS_OF_BY_CLASS)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RepresentationBySignImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RepresentationBySignImpl.java
@@ -54,32 +54,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RepresentationBySignImpl extends HqdmObject implements RepresentationBySign {
     /**
+     * Constructs a new RepresentationBySign.
      *
-     * @param iri
+     * @param iri IRI of the RepresentationBySign.
      */
     public RepresentationBySignImpl(final IRI iri) {
         super(RepresentationBySignImpl.class, iri, REPRESENTATION_BY_SIGN);
     }
 
     /**
-     * Builder for RepresentationBySignImpl.
+     * Builder for constructing instances of RepresentationBySign.
      */
     public static class Builder {
-        /** */
+
         private final RepresentationBySignImpl representationBySignImpl;
 
         /**
+         * Constructs a Builder for a new RepresentationBySign.
          *
-         * @param iri
+         * @param iri IRI of the RepresentationBySign.
          */
         public Builder(final IRI iri) {
             representationBySignImpl = new RepresentationBySignImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             representationBySignImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -87,9 +95,11 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             representationBySignImpl.addValue(BEGINNING, event.getIri());
@@ -97,9 +107,15 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             representationBySignImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -107,11 +123,11 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
-         * A consists_of relationship type where one or more {@link Sign} is used in the
-         * representation_by_sign.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where one or more
+         * {@link Sign} is used in the {@link RepresentationBySign}.
          *
-         * @param sign
-         * @return
+         * @param sign The Sign.
+         * @return This builder.
          */
         public final Builder consists_Of(final Sign sign) {
             representationBySignImpl.addValue(CONSISTS_OF, sign.getIri());
@@ -119,11 +135,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
-         * A consists_of relationship type where a representation_by_sign consists of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where a
+         * {@link RepresentationBySign} consists of one or more
          * {@link RecognizingLanguageCommunity}.
          *
-         * @param recognizingLanguageCommunity
-         * @return
+         * @param recognizingLanguageCommunity The RecognizingLanguageCommunity.
+         * @return This builder.
          */
         public final Builder consists_Of_(
                 final RecognizingLanguageCommunity recognizingLanguageCommunity) {
@@ -132,9 +149,16 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Association} consists of two or more participants.
          *
-         * @param participant
-         * @return
+         * <p>
+         * Note: The cardinality constraint shows a minimum cardinality of one because this
+         * relationship will be retyped for particular participants in an association.
+         * </p>
+         *
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             representationBySignImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -142,9 +166,11 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             representationBySignImpl.addValue(ENDING, event.getIri());
@@ -152,9 +178,10 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             representationBySignImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -162,11 +189,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
-         * A member_of relationship type where the representation_by_sign may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where the
+         * {@link RepresentationBySign} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfRepresentation}.
          *
-         * @param classOfRepresentation
-         * @return
+         * @param classOfRepresentation The ClassOfRepresentation.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRepresentation classOfRepresentation) {
             representationBySignImpl.addValue(MEMBER_OF, classOfRepresentation.getIri());
@@ -174,11 +202,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
-         * A member_of relationship type where the representation_by_sign must be a member_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where the
+         * {@link RepresentationBySign} must be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
          * exactly one {@link RepresentationByPattern}.
          *
-         * @param representationByPattern
-         * @return
+         * @param representationByPattern The RepresentationByPattern.
+         * @return This builder.
          */
         public final Builder member_Of__M(final RepresentationByPattern representationByPattern) {
             representationBySignImpl.addValue(MEMBER_OF_, representationByPattern.getIri());
@@ -186,9 +215,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Association} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfAssociation}.
          *
-         * @param kindOfAssociation
-         * @return
+         * @param kindOfAssociation The KindOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfAssociation kindOfAssociation) {
             representationBySignImpl.addValue(MEMBER_OF_KIND, kindOfAssociation.getIri());
@@ -196,9 +228,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             representationBySignImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -206,9 +241,17 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             representationBySignImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -216,10 +259,11 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
-         * A relationship type where a representation_by_sign represents one or more {@link Thing}.
+         * A relationship type where a {@link RepresentationBySign} represents one or more
+         * {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder represents_M(final Thing thing) {
             representationBySignImpl.addValue(REPRESENTS, thing.getIri());
@@ -227,9 +271,12 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             representationBySignImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -237,9 +284,21 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             representationBySignImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -247,9 +306,11 @@ public class RepresentationBySignImpl extends HqdmObject implements Representati
         }
 
         /**
+         * Returns an instance of RepresentationBySign created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built RepresentationBySign.
+         * @throws HqdmException If the RepresentationBySign is missing any mandatory properties.
          */
         public RepresentationBySign build() throws HqdmException {
             if (representationBySignImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RequirementImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RequirementImpl.java
@@ -44,32 +44,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RequirementImpl extends HqdmObject implements Requirement {
     /**
+     * Constructs a new Requirement.
      *
-     * @param iri
+     * @param iri IRI of the Requirement.
      */
     public RequirementImpl(final IRI iri) {
         super(RequirementImpl.class, iri, REQUIREMENT);
     }
 
     /**
-     * Builder for RequirementImpl.
+     * Builder for constructing instances of Requirement.
      */
     public static class Builder {
-        /** */
+
         private final RequirementImpl requirementImpl;
 
         /**
+         * Constructs a Builder for a new Requirement.
          *
-         * @param iri
+         * @param iri IRI of the Requirement.
          */
         public Builder(final IRI iri) {
             requirementImpl = new RequirementImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             requirementImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -77,9 +85,11 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             requirementImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             requirementImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,11 +113,12 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
-         * A member_of relationship type where a requirement is defined_by exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link Requirement} is {@link uk.gov.gchq.hqdm.iri.HQDM#DEFINED_BY} exactly one
          * {@link RequirementSpecification}.
          *
-         * @param requirementSpecification
-         * @return
+         * @param requirementSpecification The RequirementSpecification.
+         * @return This builder.
          */
         public final Builder defined_By_M(final RequirementSpecification requirementSpecification) {
             requirementImpl.addValue(DEFINED_BY, requirementSpecification.getIri());
@@ -109,9 +126,11 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             requirementImpl.addValue(ENDING, event.getIri());
@@ -119,9 +138,11 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             requirementImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -129,9 +150,12 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SpatioTemporalExtent} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -140,9 +164,12 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             requirementImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,10 +177,11 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
-         * A part_of relationship type where a requirement must be part_of one or more {@link Plan}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a {@link Requirement}
+         * must be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link Plan}.
          *
-         * @param plan
-         * @return
+         * @param plan The Plan.
+         * @return This builder.
          */
         public final Builder part_Of_Plan_M(final Plan plan) {
             requirementImpl.addValue(PART_OF_PLAN, plan.getIri());
@@ -161,9 +189,17 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             requirementImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -171,9 +207,12 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             requirementImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +220,10 @@ public class RequirementImpl extends HqdmObject implements Requirement {
         }
 
         /**
+         * Returns an instance of Requirement created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Requirement.
+         * @throws HqdmException If the Requirement is missing any mandatory properties.
          */
         public Requirement build() throws HqdmException {
             if (requirementImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RequirementSpecificationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RequirementSpecificationImpl.java
@@ -38,32 +38,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RequirementSpecificationImpl extends HqdmObject implements RequirementSpecification {
     /**
+     * Constructs a new RequirementSpecification.
      *
-     * @param iri
+     * @param iri IRI of the RequirementSpecification.
      */
     public RequirementSpecificationImpl(final IRI iri) {
         super(RequirementSpecificationImpl.class, iri, REQUIREMENT_SPECIFICATION);
     }
 
     /**
-     * Builder for RequirementSpecificationImpl.
+     * Builder for constructing instances of RequirementSpecification.
      */
     public static class Builder {
-        /** */
+
         private final RequirementSpecificationImpl requirementSpecificationImpl;
 
         /**
+         * Constructs a Builder for a new RequirementSpecification.
          *
-         * @param iri
+         * @param iri IRI of the RequirementSpecification.
          */
         public Builder(final IRI iri) {
             requirementSpecificationImpl = new RequirementSpecificationImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -73,9 +79,11 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             requirementSpecificationImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -83,11 +91,11 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
-         * A subtype_of relationship type where each requirement_specification is the
-         * intersection_of one or more {@link ClassOfState}.
+         * A subtype_of relationship type where each {@link RequirementSpecification} is the
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#INTERSECTION_OF} one or more {@link ClassOfState}.
          *
-         * @param classOfState
-         * @return
+         * @param classOfState The ClassOfState.
+         * @return This builder.
          */
         public final Builder intersection_Of_M(final ClassOfState classOfState) {
             requirementSpecificationImpl.addValue(INTERSECTION_OF, classOfState.getIri());
@@ -95,9 +103,11 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             requirementSpecificationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -105,9 +115,11 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             requirementSpecificationImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -115,9 +127,12 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -127,9 +142,12 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -139,9 +157,12 @@ public class RequirementSpecificationImpl extends HqdmObject implements Requirem
         }
 
         /**
+         * Returns an instance of RequirementSpecification created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built RequirementSpecification.
+         * @throws HqdmException If the RequirementSpecification is missing any mandatory
+         *         properties.
          */
         public RequirementSpecification build() throws HqdmException {
             if (requirementSpecificationImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/RoleImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/RoleImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class RoleImpl extends HqdmObject implements Role {
     /**
+     * Constructs a new Role.
      *
-     * @param iri
+     * @param iri IRI of the Role.
      */
     public RoleImpl(final IRI iri) {
         super(RoleImpl.class, iri, ROLE);
     }
 
     /**
-     * Builder for RoleImpl.
+     * Builder for constructing instances of Role.
      */
     public static class Builder {
-        /** */
+
         private final RoleImpl roleImpl;
 
         /**
+         * Constructs a Builder for a new Role.
          *
-         * @param iri
+         * @param iri IRI of the Role.
          */
         public Builder(final IRI iri) {
             roleImpl = new RoleImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             roleImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +92,11 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             roleImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -94,9 +104,11 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             roleImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -104,9 +116,12 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -115,9 +130,12 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -126,11 +144,13 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
-         * A part_of_by_class where a member_of a role is a participant in a member_of a
-         * {@link KindOfActivity}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link Role} is a
+         * {@link uk.gov.gchq.hqdm.model.Participant} in a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class(final KindOfActivity kindOfActivity) {
             roleImpl.addValue(PART_OF_BY_CLASS, kindOfActivity.getIri());
@@ -138,10 +158,13 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
-         * A part_of_by_class where a member_of a role is a part_of a member_of the class.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link Role} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * the class.
          *
-         * @param kindOfAssociation
-         * @return
+         * @param kindOfAssociation The KindOfAssociation.
+         * @return This builder.
          */
         public final Builder part_Of_By_Class_(final KindOfAssociation kindOfAssociation) {
             roleImpl.addValue(PART_OF_BY_CLASS_, kindOfAssociation.getIri());
@@ -149,9 +172,10 @@ public class RoleImpl extends HqdmObject implements Role {
         }
 
         /**
+         * Returns an instance of Role created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Role.
+         * @throws HqdmException If the Role is missing any mandatory properties.
          */
         public Role build() throws HqdmException {
             if (roleImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SaleOfGoodsImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SaleOfGoodsImpl.java
@@ -58,32 +58,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
     /**
+     * Constructs a new SaleOfGoods.
      *
-     * @param iri
+     * @param iri IRI of the SaleOfGoods.
      */
     public SaleOfGoodsImpl(final IRI iri) {
         super(SaleOfGoodsImpl.class, iri, SALE_OF_GOODS);
     }
 
     /**
-     * Builder for SaleOfGoodsImpl.
+     * Builder for constructing instances of SaleOfGoods.
      */
     public static class Builder {
-        /** */
+
         private final SaleOfGoodsImpl saleOfGoodsImpl;
 
         /**
+         * Constructs a Builder for a new SaleOfGoods.
          *
-         * @param iri
+         * @param iri IRI of the SaleOfGoods.
          */
         public Builder(final IRI iri) {
             saleOfGoodsImpl = new SaleOfGoodsImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             saleOfGoodsImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -91,9 +99,11 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             saleOfGoodsImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +111,11 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.model.Activity} is the cause of
+         * one or more {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             saleOfGoodsImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +123,15 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             saleOfGoodsImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,11 +139,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
-         * A consists_of relationship type where a sale_of_goods consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where a
+         * {@link SaleOfGoods} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link OfferAndAcceptanceForGoods}.
          *
-         * @param offerAndAcceptanceForGoods
-         * @return
+         * @param offerAndAcceptanceForGoods The OfferAndAcceptanceForGoods.
+         * @return Builder
          */
         public final Builder consists_Of(
                 final OfferAndAcceptanceForGoods offerAndAcceptanceForGoods) {
@@ -134,11 +153,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
-         * A consists_of relationship type where a sale_of_goods consists_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where a
+         * {@link SaleOfGoods} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} exactly one
          * {@link ExchangeOfGoodsAndMoney}.
          *
-         * @param exchangeOfGoodsAndMoney
-         * @return
+         * @param exchangeOfGoodsAndMoney The ExchangeOfGoodsAndMoney.
+         * @return Builder
          */
         public final Builder consists_Of_(final ExchangeOfGoodsAndMoney exchangeOfGoodsAndMoney) {
             saleOfGoodsImpl.addValue(CONSISTS_OF_, exchangeOfGoodsAndMoney.getIri());
@@ -146,9 +166,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one
+         * or more {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             saleOfGoodsImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -156,9 +179,11 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may determine one or
+         * more {@link Thing} to be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             saleOfGoodsImpl.addValue(DETERMINES, thing.getIri());
@@ -166,9 +191,11 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             saleOfGoodsImpl.addValue(ENDING, event.getIri());
@@ -176,9 +203,10 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             saleOfGoodsImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -186,9 +214,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a contract process
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfContractProcess}.
          *
-         * @param classOfContractProcess
-         * @return
+         * @param classOfContractProcess The ClassOfContractProcess.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfContractProcess classOfContractProcess) {
             saleOfGoodsImpl.addValue(MEMBER_OF, classOfContractProcess.getIri());
@@ -196,9 +227,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             saleOfGoodsImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -206,9 +240,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             saleOfGoodsImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -216,9 +253,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link ReachingAgreement}.
          *
-         * @param reachingAgreement
-         * @return
+         * @param reachingAgreement The ReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of(final ReachingAgreement reachingAgreement) {
             saleOfGoodsImpl.addValue(PART_OF, reachingAgreement.getIri());
@@ -226,9 +266,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             saleOfGoodsImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -236,9 +279,17 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             saleOfGoodsImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -246,9 +297,11 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Activity} may reference one or
+         * more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             saleOfGoodsImpl.addValue(REFERENCES, thing.getIri());
@@ -256,9 +309,12 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             saleOfGoodsImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -266,9 +322,21 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             saleOfGoodsImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -276,9 +344,10 @@ public class SaleOfGoodsImpl extends HqdmObject implements SaleOfGoods {
         }
 
         /**
+         * Returns an instance of SaleOfGoods created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SaleOfGoods.
+         * @throws HqdmException If the SaleOfGoods is missing any mandatory properties.
          */
         public SaleOfGoods build() throws HqdmException {
             if (saleOfGoodsImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductImpl.java
@@ -40,32 +40,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SalesProductImpl extends HqdmObject implements SalesProduct {
     /**
+     * Constructs a new SalesProduct.
      *
-     * @param iri
+     * @param iri IRI of the SalesProduct.
      */
     public SalesProductImpl(final IRI iri) {
         super(SalesProductImpl.class, iri, SALES_PRODUCT);
     }
 
     /**
-     * Builder for SalesProductImpl.
+     * Builder for constructing instances of SalesProduct.
      */
     public static class Builder {
-        /** */
+
         private final SalesProductImpl salesProductImpl;
 
         /**
+         * Constructs a Builder for a new SalesProduct.
          *
-         * @param iri
+         * @param iri IRI of the SalesProduct.
          */
         public Builder(final IRI iri) {
             salesProductImpl = new SalesProductImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             salesProductImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,12 +92,14 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
-         * A subclass_of relationship type where when a sales_product meets_specification of a
-         * {@link RequirementSpecification}, each member_of a sales_product is a member_of the
+         * A subclass_of relationship type where when a {@link SalesProduct}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEETS_SPECIFICATION} of a
+         * {@link RequirementSpecification}, each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link SalesProduct} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
          * {@link RequirementSpecification}.
          *
-         * @param requirementSpecification
-         * @return
+         * @param requirementSpecification The RequirementSpecification.
+         * @return This builder.
          */
         public final Builder meets_Specification(
                 final RequirementSpecification requirementSpecification) {
@@ -98,9 +108,11 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             salesProductImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -108,9 +120,11 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             salesProductImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -118,9 +132,12 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -129,9 +146,12 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -140,10 +160,11 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
-         * A specialization where the sales_product is sold under a {@link ProductBrand}.
+         * A {@link uk.gov.gchq.hqdm.model.Specialization} where the {@link SalesProduct} is sold
+         * under a {@link ProductBrand}.
          *
-         * @param productBrand
-         * @return
+         * @param productBrand The ProductBrand.
+         * @return This builder.
          */
         public final Builder sold_Under(final ProductBrand productBrand) {
             salesProductImpl.addValue(SOLD_UNDER, productBrand.getIri());
@@ -151,9 +172,10 @@ public class SalesProductImpl extends HqdmObject implements SalesProduct {
         }
 
         /**
+         * Returns an instance of SalesProduct created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SalesProduct.
+         * @throws HqdmException If the SalesProduct is missing any mandatory properties.
          */
         public SalesProduct build() throws HqdmException {
             if (salesProductImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductInstanceImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductInstanceImpl.java
@@ -45,32 +45,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SalesProductInstanceImpl extends HqdmObject implements SalesProductInstance {
     /**
+     * Constructs a new SalesProductInstance.
      *
-     * @param iri
+     * @param iri IRI of the SalesProductInstance.
      */
     public SalesProductInstanceImpl(final IRI iri) {
         super(SalesProductInstanceImpl.class, iri, SALES_PRODUCT_INSTANCE);
     }
 
     /**
-     * Builder for SalesProductInstanceImpl.
+     * Builder for constructing instances of SalesProductInstance.
      */
     public static class Builder {
-        /** */
+
         private final SalesProductInstanceImpl salesProductInstanceImpl;
 
         /**
+         * Constructs a Builder for a new SalesProductInstance.
          *
-         * @param iri
+         * @param iri IRI of the SalesProductInstance.
          */
         public Builder(final IRI iri) {
             salesProductInstanceImpl = new SalesProductInstanceImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             salesProductInstanceImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -78,9 +86,11 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             salesProductInstanceImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             salesProductInstanceImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -98,9 +114,11 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             salesProductInstanceImpl.addValue(ENDING, event.getIri());
@@ -108,9 +126,11 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.FunctionalObject} has one or
+         * more intended {@link Role}(s).
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder intended_Role_M(final Role role) {
             salesProductInstanceImpl.addValue(INTENDED_ROLE, role.getIri());
@@ -118,9 +138,11 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             salesProductInstanceImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -128,11 +150,12 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
-         * A member_of relationship type where a sales_product_instance may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SalesProductInstance} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfSalesProductInstance}.
          *
-         * @param classOfSalesProductInstance
-         * @return
+         * @param classOfSalesProductInstance The ClassOfSalesProductInstance.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSalesProductInstance classOfSalesProductInstance) {
@@ -141,9 +164,13 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where an
+         * {@link uk.gov.gchq.hqdm.model.OrdinaryFunctionalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfOrdinaryFunctionalObject}.
          *
-         * @param kindOfOrdinaryFunctionalObject
-         * @return
+         * @param kindOfOrdinaryFunctionalObject The KindOfOrdinaryFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfOrdinaryFunctionalObject kindOfOrdinaryFunctionalObject) {
@@ -153,9 +180,12 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             salesProductInstanceImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +193,17 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             salesProductInstanceImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +211,12 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             salesProductInstanceImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +224,13 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfSalesProductInstance} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link SalesProductInstance}.
          *
-         * @param salesProductInstance
-         * @return
+         * @param salesProductInstance The SalesProductInstance.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final SalesProductInstance salesProductInstance) {
             salesProductInstanceImpl.addValue(TEMPORAL_PART_OF, salesProductInstance.getIri());
@@ -193,9 +238,11 @@ public class SalesProductInstanceImpl extends HqdmObject implements SalesProduct
         }
 
         /**
+         * Returns an instance of SalesProductInstance created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SalesProductInstance.
+         * @throws HqdmException If the SalesProductInstance is missing any mandatory properties.
          */
         public SalesProductInstance build() throws HqdmException {
             if (salesProductInstanceImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductVersionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SalesProductVersionImpl.java
@@ -39,32 +39,38 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SalesProductVersionImpl extends HqdmObject implements SalesProductVersion {
     /**
+     * Constructs a new SalesProductVersion.
      *
-     * @param iri
+     * @param iri IRI of the SalesProductVersion.
      */
     public SalesProductVersionImpl(final IRI iri) {
         super(SalesProductVersionImpl.class, iri, SALES_PRODUCT_VERSION);
     }
 
     /**
-     * Builder for SalesProductVersionImpl.
+     * Builder for constructing instances of SalesProductVersion.
      */
     public static class Builder {
-        /** */
+
         private final SalesProductVersionImpl salesProductVersionImpl;
 
         /**
+         * Constructs a Builder for a new SalesProductVersion.
          *
-         * @param iri
+         * @param iri IRI of the SalesProductVersion.
          */
         public Builder(final IRI iri) {
             salesProductVersionImpl = new SalesProductVersionImpl(iri);
         }
 
         /**
+         * An inverse {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF_BY_CLASS} relationship type where a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one {@link ClassOfSpatioTemporalExtent}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} another
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -74,9 +80,11 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * A relationship type where each {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the
+         * {@link Class} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} the superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder has_Superclass(final Class clazz) {
             salesProductVersionImpl.addValue(HAS_SUPERCLASS, clazz.getIri());
@@ -84,9 +92,11 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             salesProductVersionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -94,9 +104,11 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Class} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfClass}.
          *
-         * @param classOfClass
-         * @return
+         * @param classOfClass The ClassOfClass.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfClass classOfClass) {
             salesProductVersionImpl.addValue(MEMBER_OF, classOfClass.getIri());
@@ -104,9 +116,12 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link ClassOfSpatioTemporalExtent} may be a member of one or more
+         * {@link ClassOfClassOfSpatioTemporalExtent}.
          *
-         * @param classOfClassOfSpatioTemporalExtent
-         * @return
+         * @param classOfClassOfSpatioTemporalExtent The ClassOfClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of_(
                 final ClassOfClassOfSpatioTemporalExtent classOfClassOfSpatioTemporalExtent) {
@@ -116,9 +131,12 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
+         * {@link ClassOfSpatioTemporalExtent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} some {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of_By_Class(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -128,10 +146,11 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
-         * A specialization where the sales_product_version may be sold as a {@link SalesProduct}.
+         * A {@link uk.gov.gchq.hqdm.model.Specialization} where the {@link SalesProductVersion} may
+         * be sold as a {@link SalesProduct}.
          *
-         * @param salesProduct
-         * @return
+         * @param salesProduct The SalesProduct.
+         * @return This builder.
          */
         public final Builder sold_As(final SalesProduct salesProduct) {
             salesProductVersionImpl.addValue(SOLD_AS, salesProduct.getIri());
@@ -139,10 +158,10 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
-         * A relationship type where a sales_product_version may have exactly one successor.
+         * A relationship type where a {@link SalesProductVersion} may have exactly one successor.
          *
-         * @param salesProductVersion
-         * @return
+         * @param salesProductVersion The SalesProductVersion.
+         * @return This builder.
          */
         public final Builder successor(final SalesProductVersion salesProductVersion) {
             salesProductVersionImpl.addValue(SUCCESSOR, salesProductVersion.getIri());
@@ -150,9 +169,11 @@ public class SalesProductVersionImpl extends HqdmObject implements SalesProductV
         }
 
         /**
+         * Returns an instance of SalesProductVersion created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SalesProductVersion.
+         * @throws HqdmException If the SalesProductVersion is missing any mandatory properties.
          */
         public SalesProductVersion build() throws HqdmException {
             if (salesProductVersionImpl.hasValue(HAS_SUPERCLASS)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ScaleImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ScaleImpl.java
@@ -34,33 +34,35 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class ScaleImpl extends HqdmObject implements Scale {
     /**
+     * Constructs a new Scale.
      *
-     * @param iri
+     * @param iri IRI of the Scale.
      */
     public ScaleImpl(final IRI iri) {
         super(ScaleImpl.class, iri, SCALE);
     }
 
     /**
-     * Builder for ScaleImpl.
+     * Builder for constructing instances of Scale.
      */
     public static class Builder {
-        /** */
+
         private final ScaleImpl scaleImpl;
 
         /**
+         * Constructs a Builder for a new Scale.
          *
-         * @param iri
+         * @param iri IRI of the Scale.
          */
         public Builder(final IRI iri) {
             scaleImpl = new ScaleImpl(iri);
         }
 
         /**
-         * A scale has exactly one {@link KindOfPhysicalQuantity} as its domain.
+         * A {@link Scale} has exactly one {@link KindOfPhysicalQuantity} as its domain.
          *
-         * @param kindOfPhysicalQuantity
-         * @return
+         * @param kindOfPhysicalQuantity The KindOfPhysicalQuantity.
+         * @return This builder.
          */
         public final Builder domain_M(final KindOfPhysicalQuantity kindOfPhysicalQuantity) {
             scaleImpl.addValue(DOMAIN, kindOfPhysicalQuantity.getIri());
@@ -68,9 +70,11 @@ public class ScaleImpl extends HqdmObject implements Scale {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             scaleImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -78,9 +82,11 @@ public class ScaleImpl extends HqdmObject implements Scale {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             scaleImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -88,10 +94,22 @@ public class ScaleImpl extends HqdmObject implements Scale {
         }
 
         /**
-         * A scale may have at most one {@link UnitOfMeasure}.
+         * A {@link Scale} may have at most one {@link UnitOfMeasure}.
          *
-         * @param unitOfMeasure
-         * @return
+         * <p>
+         * Note 1: A {@link UnitOfMeasure} may apply to more than one {@link Scale}.
+         * </p>
+         * <p>
+         * Note 2: A {@link Scale} may not have a {@link UnitOfMeasure}. To have a
+         * {@link UnitOfMeasure} the points on the {@link Scale} must be evenly placed so that
+         * adding one means the same {@link uk.gov.gchq.hqdm.model.Thing}. This is not true for some
+         * {@link Scale}s such as Rockwell Hardness where the points on the {@link Scale} are an
+         * arbitrary distance apart. A {@link Scale} will also not have a {@link UnitOfMeasure} when
+         * it is a dimensionless {@link Scale}.
+         * </p>
+         *
+         * @param unitOfMeasure The UnitOfMeasure.
+         * @return This builder.
          */
         public final Builder unit(final UnitOfMeasure unitOfMeasure) {
             scaleImpl.addValue(UNIT, unitOfMeasure.getIri());
@@ -99,9 +117,10 @@ public class ScaleImpl extends HqdmObject implements Scale {
         }
 
         /**
+         * Returns an instance of Scale created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Scale.
+         * @throws HqdmException If the Scale is missing any mandatory properties.
          */
         public Scale build() throws HqdmException {
             if (!scaleImpl.hasValue(DOMAIN)) {

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SignImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SignImpl.java
@@ -48,32 +48,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SignImpl extends HqdmObject implements Sign {
     /**
+     * Constructs a new Sign.
      *
-     * @param iri
+     * @param iri IRI of the Sign.
      */
     public SignImpl(final IRI iri) {
         super(SignImpl.class, iri, SIGN);
     }
 
     /**
-     * Builder for SignImpl.
+     * Builder for constructing instances of Sign.
      */
     public static class Builder {
-        /** */
+
         private final SignImpl signImpl;
 
         /**
+         * Constructs a Builder for a new Sign.
          *
-         * @param iri
+         * @param iri IRI of the Sign.
          */
         public Builder(final IRI iri) {
             signImpl = new SignImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             signImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -81,9 +89,11 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             signImpl.addValue(BEGINNING, event.getIri());
@@ -91,9 +101,15 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             signImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -101,9 +117,11 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             signImpl.addValue(ENDING, event.getIri());
@@ -111,9 +129,11 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             signImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -121,11 +141,11 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
-         * A member_of relationship type where a sign may be a member_of one or more
-         * {@link ClassOfSign}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Sign} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfSign}.
          *
-         * @param classOfSign
-         * @return
+         * @param classOfSign The ClassOfSign.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfSign classOfSign) {
             signImpl.addValue(MEMBER_OF, classOfSign.getIri());
@@ -133,10 +153,11 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
-         * A member_of relationship type where a sign is a member_of one or more {@link Pattern}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link Sign} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Pattern}.
          *
-         * @param pattern
-         * @return
+         * @param pattern The Pattern.
+         * @return This builder.
          */
         public final Builder member_Of__M(final Pattern pattern) {
             signImpl.addValue(MEMBER_OF_, pattern.getIri());
@@ -144,9 +165,13 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfSociallyConstructedObject}.
          *
-         * @param kindOfSociallyConstructedObject
-         * @return
+         * @param kindOfSociallyConstructedObject The KindOfSociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfSociallyConstructedObject kindOfSociallyConstructedObject) {
@@ -155,9 +180,12 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             signImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -165,9 +193,17 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             signImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -175,11 +211,12 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
-         * A participant_in relationship type where a sign is a participant_in one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where a {@link Sign}
+         * is a {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} one or more
          * {@link RepresentationBySign}.
          *
-         * @param representationBySign
-         * @return
+         * @param representationBySign The RepresentationBySign.
+         * @return This builder.
          */
         public final Builder participant_In_M(final RepresentationBySign representationBySign) {
             signImpl.addValue(PARTICIPANT_IN, representationBySign.getIri());
@@ -187,9 +224,12 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             signImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -197,9 +237,21 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             signImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -207,9 +259,10 @@ public class SignImpl extends HqdmObject implements Sign {
         }
 
         /**
+         * Returns an instance of Sign created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Sign.
+         * @throws HqdmException If the Sign is missing any mandatory properties.
          */
         public Sign build() throws HqdmException {
             if (signImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SociallyConstructedActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SociallyConstructedActivityImpl.java
@@ -57,32 +57,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class SociallyConstructedActivityImpl extends HqdmObject
         implements SociallyConstructedActivity {
     /**
+     * Constructs a new SociallyConstructedActivity.
      *
-     * @param iri
+     * @param iri IRI of the SociallyConstructedActivity.
      */
     public SociallyConstructedActivityImpl(final IRI iri) {
         super(SociallyConstructedActivityImpl.class, iri, SOCIALLY_CONSTRUCTED_ACTIVITY);
     }
 
     /**
-     * Builder for SociallyConstructedActivityImpl.
+     * Builder for constructing instances of SociallyConstructedActivity.
      */
     public static class Builder {
-        /** */
+
         private final SociallyConstructedActivityImpl sociallyConstructedActivityImpl;
 
         /**
+         * Constructs a Builder for a new SociallyConstructedActivity.
          *
-         * @param iri
+         * @param iri IRI of the SociallyConstructedActivity.
          */
         public Builder(final IRI iri) {
             sociallyConstructedActivityImpl = new SociallyConstructedActivityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedActivityImpl.addValue(AGGREGATED_INTO,
@@ -91,9 +99,11 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             sociallyConstructedActivityImpl.addValue(BEGINNING, event.getIri());
@@ -101,9 +111,11 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             sociallyConstructedActivityImpl.addValue(CAUSES, event.getIri());
@@ -111,9 +123,15 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedActivityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -121,9 +139,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             sociallyConstructedActivityImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -131,9 +152,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more
+         * {@link Participant}s.
          *
-         * @param participant
-         * @return
+         * @param participant The Participant.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Participant participant) {
             sociallyConstructedActivityImpl.addValue(CONSISTS_OF_PARTICIPANT, participant.getIri());
@@ -141,9 +165,11 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             sociallyConstructedActivityImpl.addValue(DETERMINES, thing.getIri());
@@ -151,9 +177,11 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             sociallyConstructedActivityImpl.addValue(ENDING, event.getIri());
@@ -161,9 +189,10 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             sociallyConstructedActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -171,11 +200,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a socially_constructed_activity may be a member_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SociallyConstructedActivity} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
          * one or more {@link ClassOfSociallyConstructedActivity}.
          *
-         * @param classOfSociallyConstructedActivity
-         * @return
+         * @param classOfSociallyConstructedActivity The ClassOfSociallyConstructedActivity.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedActivity classOfSociallyConstructedActivity) {
@@ -185,9 +215,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             sociallyConstructedActivityImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -195,9 +228,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedActivityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -205,11 +241,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
-         * A part_of relationship type where a socially_constructed_activity may be a part_of one or
-         * more {@link ReachingAgreement}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SociallyConstructedActivity} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF}
+         * one or more {@link ReachingAgreement}.
          *
-         * @param reachingAgreement
-         * @return
+         * @param reachingAgreement The ReachingAgreement.
+         * @return This builder.
          */
         public final Builder part_Of(final ReachingAgreement reachingAgreement) {
             sociallyConstructedActivityImpl.addValue(PART_OF, reachingAgreement.getIri());
@@ -217,11 +254,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
-         * A part_of relationship type where a socially_constructed_object may be a part_of one or
-         * more {@link AgreementExecution}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             sociallyConstructedActivityImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -229,9 +267,17 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             sociallyConstructedActivityImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -240,9 +286,10 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link Activity} may reference one or more {@link Thing}.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder references(final Thing thing) {
             sociallyConstructedActivityImpl.addValue(REFERENCES, thing.getIri());
@@ -250,9 +297,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedActivityImpl.addValue(TEMPORAL__PART_OF,
@@ -261,9 +311,21 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             sociallyConstructedActivityImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -271,9 +333,12 @@ public class SociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of SociallyConstructedActivity created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SociallyConstructedActivity.
+         * @throws HqdmException If the SociallyConstructedActivity is missing any mandatory
+         *         properties.
          */
         public SociallyConstructedActivity build() throws HqdmException {
             if (sociallyConstructedActivityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SociallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SociallyConstructedObjectImpl.java
@@ -44,32 +44,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SociallyConstructedObjectImpl extends HqdmObject implements SociallyConstructedObject {
     /**
+     * Constructs a new SociallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the SociallyConstructedObject.
      */
     public SociallyConstructedObjectImpl(final IRI iri) {
         super(SociallyConstructedObjectImpl.class, iri, SOCIALLY_CONSTRUCTED_OBJECT);
     }
 
     /**
-     * Builder for SociallyConstructedObjectImpl.
+     * Builder for constructing instances of SociallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         private final SociallyConstructedObjectImpl sociallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new SociallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the SociallyConstructedObject.
          */
         public Builder(final IRI iri) {
             sociallyConstructedObjectImpl = new SociallyConstructedObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -77,9 +85,11 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             sociallyConstructedObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             sociallyConstructedObjectImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             sociallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
-         * A member_of relationship type where a socially_constructed_object may be a member_of one
-         * or more {@link ClassOfSociallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SociallyConstructedObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link ClassOfSociallyConstructedObject}.
          *
-         * @param classOfSociallyConstructedObject
-         * @return
+         * @param classOfSociallyConstructedObject The ClassOfSociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedObject classOfSociallyConstructedObject) {
@@ -131,11 +152,12 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
-         * A member_of_kind where a socially_constructed_object may be a member_of one or more
-         * {@link KindOfSociallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link SociallyConstructedObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
+         * one or more {@link KindOfSociallyConstructedObject}.
          *
-         * @param kindOfSociallyConstructedObject
-         * @return
+         * @param kindOfSociallyConstructedObject The KindOfSociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(
                 final KindOfSociallyConstructedObject kindOfSociallyConstructedObject) {
@@ -145,9 +167,12 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -155,9 +180,17 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             sociallyConstructedObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -165,9 +198,12 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             sociallyConstructedObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -176,9 +212,21 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             sociallyConstructedObjectImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -186,9 +234,12 @@ public class SociallyConstructedObjectImpl extends HqdmObject implements Sociall
         }
 
         /**
+         * Returns an instance of SociallyConstructedObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SociallyConstructedObject.
+         * @throws HqdmException If the SociallyConstructedObject is missing any mandatory
+         *         properties.
          */
         public SociallyConstructedObject build() throws HqdmException {
             if (sociallyConstructedObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SpatioTemporalExtentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SpatioTemporalExtentImpl.java
@@ -39,34 +39,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTemporalExtent {
     /**
+     * Constructs a new SpatioTemporalExtent.
      *
-     * @param iri
+     * @param iri IRI of the SpatioTemporalExtent.
      */
     public SpatioTemporalExtentImpl(final IRI iri) {
         super(SpatioTemporalExtentImpl.class, iri, SPATIO_TEMPORAL_EXTENT);
     }
 
     /**
-     * Builder for SpatioTemporalExtentImpl.
+     * Builder for constructing instances of SpatioTemporalExtent.
      */
     public static class Builder {
-        /** */
+
         private final SpatioTemporalExtentImpl spatioTemporalExtentImpl;
 
         /**
+         * Constructs a Builder for a new SpatioTemporalExtent.
          *
-         * @param iri
+         * @param iri IRI of the SpatioTemporalExtent.
          */
         public Builder(final IRI iri) {
             spatioTemporalExtentImpl = new SpatioTemporalExtentImpl(iri);
         }
 
         /**
-         * A relationship type where a spatio_temporal_extent may be aggregated into one or more
-         * others.
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             spatioTemporalExtentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -74,11 +76,11 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A part_of relationship type where a spatio_temporal_extent has exactly one {@link Event}
-         * that is its beginning.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             spatioTemporalExtentImpl.addValue(BEGINNING, event.getIri());
@@ -86,10 +88,11 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A relationship type where a spatio_temporal_extent may consist of one or more others.
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             spatioTemporalExtentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,11 +100,11 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A part_of relationship type where a spatio_temporal_extent has exactly one {@link Event}
-         * that is its ending.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             spatioTemporalExtentImpl.addValue(ENDING, event.getIri());
@@ -109,9 +112,11 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             spatioTemporalExtentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +124,12 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A member_of relationship type where a spatio_temporal_extent is a member_of a
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SpatioTemporalExtent} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a
          * {@link ClassOfSpatioTemporalExtent}.
          *
-         * @param classOfSpatioTemporalExtent
-         * @return
+         * @param classOfSpatioTemporalExtent The ClassOfSpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSpatioTemporalExtent classOfSpatioTemporalExtent) {
@@ -132,11 +138,12 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * An aggregated_into relationship type where a spatio_temporal_extent may be part of
-         * another and the whole has emergent properties and is more than just the sum of its parts.
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO}relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             spatioTemporalExtentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -144,11 +151,12 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A part_of relationship type where a spatio_temporal_extent may be part_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
          * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             spatioTemporalExtentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -156,11 +164,12 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
-         * A part_of relationship type where a spatio_temporal_extent may be a temporal part of one
-         * or more other spatio_temporal_extent.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             spatioTemporalExtentImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -168,9 +177,11 @@ public class SpatioTemporalExtentImpl extends HqdmObject implements SpatioTempor
         }
 
         /**
+         * Returns an instance of SpatioTemporalExtent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SpatioTemporalExtent.
+         * @throws HqdmException If the SpatioTemporalExtent is missing any mandatory properties.
          */
         public SpatioTemporalExtent build() throws HqdmException {
             if (spatioTemporalExtentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SpecializationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SpecializationImpl.java
@@ -32,32 +32,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SpecializationImpl extends HqdmObject implements Specialization {
     /**
+     * Constructs a new Specialization.
      *
-     * @param iri
+     * @param iri IRI of the Specialization.
      */
     public SpecializationImpl(final IRI iri) {
         super(SpecializationImpl.class, iri, SPECIALIZATION);
     }
 
     /**
-     * Builder for SpecializationImpl.
+     * Builder for constructing instances of Specialization.
      */
     public static class Builder {
-        /** */
+
         private final SpecializationImpl specializationImpl;
 
         /**
+         * Constructs a Builder for a new Specialization.
          *
-         * @param iri
+         * @param iri IRI of the Specialization.
          */
         public Builder(final IRI iri) {
             specializationImpl = new SpecializationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             specializationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -65,9 +69,11 @@ public class SpecializationImpl extends HqdmObject implements Specialization {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             specializationImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -75,10 +81,11 @@ public class SpecializationImpl extends HqdmObject implements Specialization {
         }
 
         /**
-         * A relationship type where each specialization has exactly one {@link Class} as subclass.
+         * A relationship type where each {@link Specialization} has exactly one {@link Class} as
+         * subclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder subclass_M(final Class clazz) {
             specializationImpl.addValue(SUBCLASS, clazz.getIri());
@@ -86,11 +93,11 @@ public class SpecializationImpl extends HqdmObject implements Specialization {
         }
 
         /**
-         * A relationship type where each specialization has exactly one {@link Class} as
+         * A relationship type where each {@link Specialization} has exactly one {@link Class} as
          * superclass.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder superclass_M(final Class clazz) {
             specializationImpl.addValue(SUPERCLASS, clazz.getIri());
@@ -98,9 +105,10 @@ public class SpecializationImpl extends HqdmObject implements Specialization {
         }
 
         /**
+         * Returns an instance of Specialization created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Specialization.
+         * @throws HqdmException If the Specialization is missing any mandatory properties.
          */
         public Specialization build() throws HqdmException {
             if (specializationImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateImpl extends HqdmObject implements State {
     /**
+     * Constructs a new State.
      *
-     * @param iri
+     * @param iri IRI of the State.
      */
     public StateImpl(final IRI iri) {
         super(StateImpl.class, iri, STATE);
     }
 
     /**
-     * Builder for StateImpl.
+     * Builder for constructing instances of State.
      */
     public static class Builder {
-        /** */
+
         private final StateImpl stateImpl;
 
         /**
+         * Constructs a Builder for a new State.
          *
-         * @param iri
+         * @param iri IRI of the State.
          */
         public Builder(final IRI iri) {
             stateImpl = new StateImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,11 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
-         * A member_of relationship type where a state may be a member_of one or more
-         * {@link ClassOfState}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link State} may
+         * be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfState}.
          *
-         * @param classOfState
-         * @return
+         * @param classOfState The ClassOfState.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfState classOfState) {
             stateImpl.addValue(MEMBER_OF, classOfState.getIri());
@@ -127,9 +147,12 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +160,17 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +178,12 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +191,20 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
-         * A temporal_part_of relationship type where a state may be a temporal_part_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link State} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
          * {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link State} as well as {@link Individual}.
+         * This applies to all subtypes of {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that
+         * are between a {@code state_of_X} and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             stateImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -169,9 +212,10 @@ public class StateImpl extends HqdmObject implements State {
         }
 
         /**
+         * Returns an instance of State created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built State.
+         * @throws HqdmException If the State is missing any mandatory properties.
          */
         public State build() throws HqdmException {
             if (stateImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfActivityImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
     /**
+     * Constructs a new StateOfActivity.
      *
-     * @param iri
+     * @param iri IRI of the StateOfActivity.
      */
     public StateOfActivityImpl(final IRI iri) {
         super(StateOfActivityImpl.class, iri, STATE_OF_ACTIVITY);
     }
 
     /**
-     * Builder for StateOfActivityImpl.
+     * Builder for constructing instances of StateOfActivity.
      */
     public static class Builder {
-        /** */
+
         private final StateOfActivityImpl stateOfActivityImpl;
 
         /**
+         * Constructs a Builder for a new StateOfActivity.
          *
-         * @param iri
+         * @param iri IRI of the StateOfActivity.
          */
         public Builder(final IRI iri) {
             stateOfActivityImpl = new StateOfActivityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfActivityImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfActivityImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfActivityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfActivityImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
-         * A member_of relationship type where a state_of_activity may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfActivity} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfActivity}.
          *
-         * @param classOfStateOfActivity
-         * @return
+         * @param classOfStateOfActivity The ClassOfStateOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfActivity classOfStateOfActivity) {
             stateOfActivityImpl.addValue(MEMBER_OF, classOfStateOfActivity.getIri());
@@ -127,9 +148,12 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfActivityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfActivityImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfActivityImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_activity may be a temporal_part_of
-         * one or more {@link Activity}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfActivity} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one
+         * or more {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Activity activity) {
             stateOfActivityImpl.addValue(TEMPORAL_PART_OF, activity.getIri());
@@ -169,9 +205,10 @@ public class StateOfActivityImpl extends HqdmObject implements StateOfActivity {
         }
 
         /**
+         * Returns an instance of StateOfActivity created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfActivity.
+         * @throws HqdmException If the StateOfActivity is missing any mandatory properties.
          */
         public StateOfActivity build() throws HqdmException {
             if (stateOfActivityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfAmountOfMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfAmountOfMoneyImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmountOfMoney {
     /**
+     * Constructs a new StateOfAmountOfMoney.
      *
-     * @param iri
+     * @param iri IRI of the StateOfAmountOfMoney.
      */
     public StateOfAmountOfMoneyImpl(final IRI iri) {
         super(StateOfAmountOfMoneyImpl.class, iri, STATE_OF_AMOUNT_OF_MONEY);
     }
 
     /**
-     * Builder for StateOfAmountOfMoneyImpl.
+     * Builder for constructing instances of StateOfAmountOfMoney.
      */
     public static class Builder {
-        /** */
+
         private final StateOfAmountOfMoneyImpl stateOfAmountOfMoneyImpl;
 
         /**
+         * Constructs a Builder for a new StateOfAmountOfMoney.
          *
-         * @param iri
+         * @param iri IRI of the StateOfAmountOfMoney.
          */
         public Builder(final IRI iri) {
             stateOfAmountOfMoneyImpl = new StateOfAmountOfMoneyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAmountOfMoneyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfAmountOfMoneyImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAmountOfMoneyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfAmountOfMoneyImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfAmountOfMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
-         * A member_of relationship type where a state_of_amount_of_money may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfAmountOfMoney} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfStateOfAmountOfMoney}.
          *
-         * @param classOfStateOfAmountOfMoney
-         * @return
+         * @param classOfStateOfAmountOfMoney The ClassOfStateOfAmountOfMoney.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfAmountOfMoney classOfStateOfAmountOfMoney) {
@@ -128,9 +149,12 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAmountOfMoneyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -138,9 +162,17 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfAmountOfMoneyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -148,9 +180,12 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAmountOfMoneyImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -158,11 +193,12 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_amount_of_money may be a
-         * temporal_part_of one or more {@link AmountOfMoney}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfAmountOfMoney} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF}
+         * one or more {@link AmountOfMoney}.
          *
-         * @param amountOfMoney
-         * @return
+         * @param amountOfMoney The AmountOfMoney.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final AmountOfMoney amountOfMoney) {
             stateOfAmountOfMoneyImpl.addValue(TEMPORAL_PART_OF, amountOfMoney.getIri());
@@ -170,9 +206,11 @@ public class StateOfAmountOfMoneyImpl extends HqdmObject implements StateOfAmoun
         }
 
         /**
+         * Returns an instance of StateOfAmountOfMoney created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfAmountOfMoney.
+         * @throws HqdmException If the StateOfAmountOfMoney is missing any mandatory properties.
          */
         public StateOfAmountOfMoney build() throws HqdmException {
             if (stateOfAmountOfMoneyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfAssociationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfAssociationImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfAssociationImpl extends HqdmObject implements StateOfAssociation {
     /**
+     * Constructs a new StateOfAssociation.
      *
-     * @param iri
+     * @param iri IRI of the StateOfAssociation.
      */
     public StateOfAssociationImpl(final IRI iri) {
         super(StateOfAssociationImpl.class, iri, STATE_OF_ASSOCIATION);
     }
 
     /**
-     * Builder for StateOfAssociationImpl.
+     * Builder for constructing instances of StateOfAssociation.
      */
     public static class Builder {
-        /** */
+
         private final StateOfAssociationImpl stateOfAssociationImpl;
 
         /**
+         * Constructs a Builder for a new StateOfAssociation.
          *
-         * @param iri
+         * @param iri IRI of the StateOfAssociation.
          */
         public Builder(final IRI iri) {
             stateOfAssociationImpl = new StateOfAssociationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAssociationImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfAssociationImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAssociationImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfAssociationImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfAssociationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
-         * A member_of relationship type where a state_of_association may be a member_of one or more
-         * {@link ClassOfStateOfAssociation}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfAssociation} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
+         * more {@link ClassOfStateOfAssociation}.
          *
-         * @param classOfStateOfAssociation
-         * @return
+         * @param classOfStateOfAssociation The ClassOfStateOfAssociation.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfAssociation classOfStateOfAssociation) {
             stateOfAssociationImpl.addValue(MEMBER_OF, classOfStateOfAssociation.getIri());
@@ -127,9 +148,12 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAssociationImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfAssociationImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfAssociationImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_association may be a
-         * temporal_part_of one or more {@link Association}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfAssociation} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF}
+         * one or more {@link Association}.
          *
-         * @param association
-         * @return
+         * @param association The Association.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Association association) {
             stateOfAssociationImpl.addValue(TEMPORAL_PART_OF, association.getIri());
@@ -169,9 +205,11 @@ public class StateOfAssociationImpl extends HqdmObject implements StateOfAssocia
         }
 
         /**
+         * Returns an instance of StateOfAssociation created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfAssociation.
+         * @throws HqdmException If the StateOfAssociation is missing any mandatory properties.
          */
         public StateOfAssociation build() throws HqdmException {
             if (stateOfAssociationImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalObjectImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBiologicalObject {
     /**
+     * Constructs a new StateOfBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfBiologicalObject.
      */
     public StateOfBiologicalObjectImpl(final IRI iri) {
         super(StateOfBiologicalObjectImpl.class, iri, STATE_OF_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfBiologicalObjectImpl.
+     * Builder for constructing instances of StateOfBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfBiologicalObjectImpl stateOfBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfBiologicalObject.
          */
         public Builder(final IRI iri) {
             stateOfBiologicalObjectImpl = new StateOfBiologicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfBiologicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfBiologicalObjectImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
-         * A member_of relationship type where a state_of_biological_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfBiologicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfStateOfBiologicalObject}.
          *
-         * @param classOfStateOfBiologicalObject
-         * @return
+         * @param classOfStateOfBiologicalObject The ClassOfStateOfBiologicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfBiologicalObject classOfStateOfBiologicalObject) {
@@ -129,9 +150,12 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -139,9 +163,17 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfBiologicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -149,9 +181,12 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -159,11 +194,12 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_biological_object may be a
-         * temporal_part_of one or more {@link BiologicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link BiologicalObject}.
          *
-         * @param biologicalObject
-         * @return
+         * @param biologicalObject The BiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final BiologicalObject biologicalObject) {
             stateOfBiologicalObjectImpl.addValue(TEMPORAL_PART_OF, biologicalObject.getIri());
@@ -171,9 +207,11 @@ public class StateOfBiologicalObjectImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * Returns an instance of StateOfBiologicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfBiologicalObject.
+         * @throws HqdmException If the StateOfBiologicalObject is missing any mandatory properties.
          */
         public StateOfBiologicalObject build() throws HqdmException {
             if (stateOfBiologicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalSystemComponentImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         implements StateOfBiologicalSystemComponent {
     /**
+     * Constructs a new StateOfBiologicalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the StateOfBiologicalSystemComponent.
      */
     public StateOfBiologicalSystemComponentImpl(final IRI iri) {
         super(StateOfBiologicalSystemComponentImpl.class, iri,
@@ -52,24 +53,31 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for StateOfBiologicalSystemComponentImpl.
+     * Builder for constructing instances of StateOfBiologicalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final StateOfBiologicalSystemComponentImpl stateOfBiologicalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new StateOfBiologicalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the StateOfBiologicalSystemComponent.
          */
         public Builder(final IRI iri) {
             stateOfBiologicalSystemComponentImpl = new StateOfBiologicalSystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemComponentImpl.addValue(AGGREGATED_INTO,
@@ -78,9 +86,11 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfBiologicalSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemComponentImpl.addValue(CONSISTS__OF,
@@ -99,9 +115,11 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfBiologicalSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfBiologicalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,14 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_biological_system_component may be a
-         * member_of one or more {@link ClassOfStateOfBiologicalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfBiologicalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfBiologicalSystemComponent}.
          *
-         * @param classOfStateOfBiologicalSystemComponent
-         * @return
+         * @param classOfStateOfBiologicalSystemComponent The
+         *        classOfStateOfBiologicalSystemComponent.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -134,9 +157,12 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -144,9 +170,17 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfBiologicalSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -155,9 +189,12 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -166,11 +203,13 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of_relationship type where a state_of_biological_system_component may be
-         * a temporal_part_of one or more {@link BiologicalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfBiologicalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link BiologicalSystemComponent}.
          *
-         * @param biologicalSystemComponent
-         * @return
+         * @param biologicalSystemComponent The BiologicalSystemComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final BiologicalSystemComponent biologicalSystemComponent) {
@@ -180,9 +219,12 @@ public class StateOfBiologicalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfBiologicalSystemComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfBiologicalSystemComponent.
+         * @throws HqdmException If the StateOfBiologicalSystemComponent is missing any mandatory
+         *         properties.
          */
         public StateOfBiologicalSystemComponent build() throws HqdmException {
             if (stateOfBiologicalSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfBiologicalSystemImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBiologicalSystem {
     /**
+     * Constructs a new StateOfBiologicalSystem.
      *
-     * @param iri
+     * @param iri IRI of the StateOfBiologicalSystem.
      */
     public StateOfBiologicalSystemImpl(final IRI iri) {
         super(StateOfBiologicalSystemImpl.class, iri, STATE_OF_BIOLOGICAL_SYSTEM);
     }
 
     /**
-     * Builder for StateOfBiologicalSystemImpl.
+     * Builder for constructing instances of StateOfBiologicalSystem.
      */
     public static class Builder {
-        /** */
+
         private final StateOfBiologicalSystemImpl stateOfBiologicalSystemImpl;
 
         /**
+         * Constructs a Builder for a new StateOfBiologicalSystem.
          *
-         * @param iri
+         * @param iri IRI of the StateOfBiologicalSystem.
          */
         public Builder(final IRI iri) {
             stateOfBiologicalSystemImpl = new StateOfBiologicalSystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfBiologicalSystemImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfBiologicalSystemImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfBiologicalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
-         * A member_of_relationship type where a state_of_biological_system may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfBiologicalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfStateOfBiologicalSystem}.
          *
-         * @param classOfStateOfBiologicalSystem
-         * @return
+         * @param classOfStateOfBiologicalSystem The ClassOfStateOfBiologicalSystem.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfBiologicalSystem classOfStateOfBiologicalSystem) {
@@ -129,9 +150,12 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -139,9 +163,17 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfBiologicalSystemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -149,9 +181,12 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfBiologicalSystemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -159,11 +194,12 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_biological_system may be a
-         * temporal_part_of one or more {@link BiologicalSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfBiologicalSystem} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link BiologicalSystem}.
          *
-         * @param biologicalSystem
-         * @return
+         * @param biologicalSystem The BiologicalSystem.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final BiologicalSystem biologicalSystem) {
             stateOfBiologicalSystemImpl.addValue(TEMPORAL_PART_OF, biologicalSystem.getIri());
@@ -171,9 +207,11 @@ public class StateOfBiologicalSystemImpl extends HqdmObject implements StateOfBi
         }
 
         /**
+         * Returns an instance of StateOfBiologicalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfBiologicalSystem.
+         * @throws HqdmException If the StateOfBiologicalSystem is missing any mandatory properties.
          */
         public StateOfBiologicalSystem build() throws HqdmException {
             if (stateOfBiologicalSystemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalObjectImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFunctionalObject {
     /**
+     * Constructs a new StateOfFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfFunctionalObject.
      */
     public StateOfFunctionalObjectImpl(final IRI iri) {
         super(StateOfFunctionalObjectImpl.class, iri, STATE_OF_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfFunctionalObjectImpl.
+     * Builder for constructing instances of StateOfFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfFunctionalObjectImpl stateOfFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfFunctionalObject.
          */
         public Builder(final IRI iri) {
             stateOfFunctionalObjectImpl = new StateOfFunctionalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfFunctionalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfFunctionalObjectImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
-         * A member_of relationship type where a state_of_functional_object may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfFunctionalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfStateOfFunctionalObject}.
          *
-         * @param classOfStateOfFunctionalObject
-         * @return
+         * @param classOfStateOfFunctionalObject The ClassOfStateOfFunctionalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfFunctionalObject classOfStateOfFunctionalObject) {
@@ -129,9 +150,12 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -139,9 +163,17 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfFunctionalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -149,9 +181,12 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -159,11 +194,12 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_functional_object may be a
-         * temporal_part_of one or more {@link FunctionalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfFunctionalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link FunctionalObject}.
          *
-         * @param functionalObject
-         * @return
+         * @param functionalObject The FunctionalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final FunctionalObject functionalObject) {
             stateOfFunctionalObjectImpl.addValue(TEMPORAL_PART_OF, functionalObject.getIri());
@@ -171,9 +207,11 @@ public class StateOfFunctionalObjectImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * Returns an instance of StateOfFunctionalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfFunctionalObject.
+         * @throws HqdmException If the StateOfFunctionalObject is missing any mandatory properties.
          */
         public StateOfFunctionalObject build() throws HqdmException {
             if (stateOfFunctionalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalSystemComponentImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         implements StateOfFunctionalSystemComponent {
     /**
+     * Constructs a new StateOfFunctionalSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the StateOfFunctionalSystemComponent.
      */
     public StateOfFunctionalSystemComponentImpl(final IRI iri) {
         super(StateOfFunctionalSystemComponentImpl.class, iri,
@@ -52,24 +53,31 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
     }
 
     /**
-     * Builder for StateOfFunctionalSystemComponentImpl.
+     * Builder for constructing instances of StateOfFunctionalSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final StateOfFunctionalSystemComponentImpl stateOfFunctionalSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new StateOfFunctionalSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the StateOfFunctionalSystemComponent.
          */
         public Builder(final IRI iri) {
             stateOfFunctionalSystemComponentImpl = new StateOfFunctionalSystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemComponentImpl.addValue(AGGREGATED_INTO,
@@ -78,9 +86,11 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfFunctionalSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemComponentImpl.addValue(CONSISTS__OF,
@@ -99,9 +115,11 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfFunctionalSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfFunctionalSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,14 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_functional_system_component may be a
-         * member_of one or more {@link ClassOfStateOfFunctionalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfFunctionalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfFunctionalSystemComponent}.
          *
-         * @param classOfStateOfFunctionalSystemComponent
-         * @return
+         * @param classOfStateOfFunctionalSystemComponent The
+         *        classOfStateOfFunctionalSystemComponent.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -134,9 +157,12 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -144,9 +170,17 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfFunctionalSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -155,9 +189,12 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -166,11 +203,13 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_functional_system_component may be
-         * a temporal_part_of one or more {@link FunctionalSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfFunctionalSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link FunctionalSystemComponent}.
          *
-         * @param functionalSystemComponent
-         * @return
+         * @param functionalSystemComponent The FunctionalSystemComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final FunctionalSystemComponent functionalSystemComponent) {
@@ -180,9 +219,12 @@ public class StateOfFunctionalSystemComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfFunctionalSystemComponent created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfFunctionalSystemComponent.
+         * @throws HqdmException If the StateOfFunctionalSystemComponent is missing any mandatory
+         *         properties.
          */
         public StateOfFunctionalSystemComponent build() throws HqdmException {
             if (stateOfFunctionalSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfFunctionalSystemImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFunctionalSystem {
     /**
+     * Constructs a new StateOfFunctionalSystem.
      *
-     * @param iri
+     * @param iri IRI of the StateOfFunctionalSystem.
      */
     public StateOfFunctionalSystemImpl(final IRI iri) {
         super(StateOfFunctionalSystemImpl.class, iri, STATE_OF_FUNCTIONAL_SYSTEM);
     }
 
     /**
-     * Builder for StateOfFunctionalSystemImpl.
+     * Builder for constructing instances of StateOfFunctionalSystem.
      */
     public static class Builder {
-        /** */
+
         private final StateOfFunctionalSystemImpl stateOfFunctionalSystemImpl;
 
         /**
+         * Constructs a Builder for a new StateOfFunctionalSystem.
          *
-         * @param iri
+         * @param iri IRI of the StateOfFunctionalSystem.
          */
         public Builder(final IRI iri) {
             stateOfFunctionalSystemImpl = new StateOfFunctionalSystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfFunctionalSystemImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfFunctionalSystemImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfFunctionalSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
-         * A member_of relationship type where a state_of_functional_system may be a member_of one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfFunctionalSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
          * or more {@link ClassOfStateOfFunctionalSystem}.
          *
-         * @param classOfStateOfFunctionalSystem
-         * @return
+         * @param classOfStateOfFunctionalSystem The ClassOfStateOfFunctionalSystem.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfFunctionalSystem classOfStateOfFunctionalSystem) {
@@ -129,9 +150,12 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -139,9 +163,17 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfFunctionalSystemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -149,9 +181,12 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfFunctionalSystemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -159,11 +194,12 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_functional_system may be a
-         * temporal_part_of one or more {@link FunctionalSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfFunctionalSystem} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link FunctionalSystem}.
          *
-         * @param functionalSystem
-         * @return
+         * @param functionalSystem The FunctionalSystem.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final FunctionalSystem functionalSystem) {
             stateOfFunctionalSystemImpl.addValue(TEMPORAL_PART_OF, functionalSystem.getIri());
@@ -171,9 +207,11 @@ public class StateOfFunctionalSystemImpl extends HqdmObject implements StateOfFu
         }
 
         /**
+         * Returns an instance of StateOfFunctionalSystem created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfFunctionalSystem.
+         * @throws HqdmException If the StateOfFunctionalSystem is missing any mandatory properties.
          */
         public StateOfFunctionalSystem build() throws HqdmException {
             if (stateOfFunctionalSystemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfIntentionallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfIntentionallyConstructedObjectImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         implements StateOfIntentionallyConstructedObject {
     /**
+     * Constructs a new StateOfIntentionallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfIntentionallyConstructedObject.
      */
     public StateOfIntentionallyConstructedObjectImpl(final IRI iri) {
         super(StateOfIntentionallyConstructedObjectImpl.class, iri,
@@ -52,16 +53,17 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for StateOfIntentionallyConstructedObjectImpl.
+     * Builder for constructing instances of StateOfIntentionallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         @SuppressWarnings("LineLength")
         private final StateOfIntentionallyConstructedObjectImpl stateOfIntentionallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfIntentionallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfIntentionallyConstructedObject.
          */
         public Builder(final IRI iri) {
             stateOfIntentionallyConstructedObjectImpl =
@@ -69,9 +71,15 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfIntentionallyConstructedObjectImpl.addValue(AGGREGATED_INTO,
@@ -80,9 +88,11 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfIntentionallyConstructedObjectImpl.addValue(BEGINNING, event.getIri());
@@ -90,9 +100,15 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfIntentionallyConstructedObjectImpl.addValue(CONSISTS__OF,
@@ -101,9 +117,11 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfIntentionallyConstructedObjectImpl.addValue(ENDING, event.getIri());
@@ -111,9 +129,11 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfIntentionallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -121,11 +141,14 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_intentionally_constructed_object may be a
-         * member_of one or more {@link ClassOfStateOfIntentionallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfIntentionallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfIntentionallyConstructedObject}.
          *
          * @param classOfStateOfIntentionallyConstructedObject
-         * @return
+         *        classOfStateOfIntentionallyConstructedObject.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -136,9 +159,12 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfIntentionallyConstructedObjectImpl.addValue(PART__OF,
@@ -147,9 +173,17 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfIntentionallyConstructedObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -158,9 +192,12 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfIntentionallyConstructedObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -169,11 +206,13 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_intentionally_constructed_object
-         * may be a temporal_part_of one or more {@link IntentionallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfIntentionallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link IntentionallyConstructedObject}.
          *
-         * @param intentionallyConstructedObject
-         * @return
+         * @param intentionallyConstructedObject The IntentionallyConstructedObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final IntentionallyConstructedObject intentionallyConstructedObject) {
@@ -183,9 +222,12 @@ public class StateOfIntentionallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfIntentionallyConstructedObject created from the properties
+         * set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfIntentionallyConstructedObject.
+         * @throws HqdmException If the StateOfIntentionallyConstructedObject is missing any
+         *         mandatory properties.
          */
         public StateOfIntentionallyConstructedObject build() throws HqdmException {
             if (stateOfIntentionallyConstructedObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfLanguageCommunityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfLanguageCommunityImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfLanguageCommunity {
     /**
+     * Constructs a new StateOfLanguageCommunity.
      *
-     * @param iri
+     * @param iri IRI of the StateOfLanguageCommunity.
      */
     public StateOfLanguageCommunityImpl(final IRI iri) {
         super(StateOfLanguageCommunityImpl.class, iri, STATE_OF_LANGUAGE_COMMUNITY);
     }
 
     /**
-     * Builder for StateOfLanguageCommunityImpl.
+     * Builder for constructing instances of StateOfLanguageCommunity.
      */
     public static class Builder {
-        /** */
+
         private final StateOfLanguageCommunityImpl stateOfLanguageCommunityImpl;
 
         /**
+         * Constructs a Builder for a new StateOfLanguageCommunity.
          *
-         * @param iri
+         * @param iri IRI of the StateOfLanguageCommunity.
          */
         public Builder(final IRI iri) {
             stateOfLanguageCommunityImpl = new StateOfLanguageCommunityImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfLanguageCommunityImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfLanguageCommunityImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfLanguageCommunityImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfLanguageCommunityImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfLanguageCommunityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,9 +135,13 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfOrganization} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrganization}.
          *
-         * @param classOfStateOfOrganization
-         * @return
+         * @param classOfStateOfOrganization The ClassOfStateOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrganization classOfStateOfOrganization) {
@@ -126,9 +150,12 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfLanguageCommunityImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -136,9 +163,17 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfLanguageCommunityImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -146,9 +181,12 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfLanguageCommunityImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -156,11 +194,12 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_language_community may be a
-         * temporal_part_of one or more {@link LanguageCommunity}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfLanguageCommunity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link LanguageCommunity}.
          *
-         * @param languageCommunity
-         * @return
+         * @param languageCommunity The LanguageCommunity.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final LanguageCommunity languageCommunity) {
             stateOfLanguageCommunityImpl.addValue(TEMPORAL_PART_OF, languageCommunity.getIri());
@@ -168,9 +207,12 @@ public class StateOfLanguageCommunityImpl extends HqdmObject implements StateOfL
         }
 
         /**
+         * Returns an instance of StateOfLanguageCommunity created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfLanguageCommunity.
+         * @throws HqdmException If the StateOfLanguageCommunity is missing any mandatory
+         *         properties.
          */
         public StateOfLanguageCommunity build() throws HqdmException {
             if (stateOfLanguageCommunityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryBiologicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryBiologicalObjectImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         implements StateOfOrdinaryBiologicalObject {
     /**
+     * Constructs a new StateOfOrdinaryBiologicalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfOrdinaryBiologicalObject.
      */
     public StateOfOrdinaryBiologicalObjectImpl(final IRI iri) {
         super(StateOfOrdinaryBiologicalObjectImpl.class, iri, STATE_OF_ORDINARY_BIOLOGICAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfOrdinaryBiologicalObjectImpl.
+     * Builder for constructing instances of StateOfOrdinaryBiologicalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfOrdinaryBiologicalObjectImpl stateOfOrdinaryBiologicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfOrdinaryBiologicalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfOrdinaryBiologicalObject.
          */
         public Builder(final IRI iri) {
             stateOfOrdinaryBiologicalObjectImpl = new StateOfOrdinaryBiologicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(AGGREGATED_INTO,
@@ -77,9 +85,11 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(CONSISTS__OF,
@@ -98,9 +114,11 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(ENDING, event.getIri());
@@ -108,9 +126,11 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -118,11 +138,13 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_ordinary_biological_object may be a
-         * member_of one or more {@link ClassOfStateOfOrdinaryBiologicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfOrdinaryBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrdinaryBiologicalObject}.
          *
-         * @param classOfStateOfOrdinaryBiologicalObject
-         * @return
+         * @param classOfStateOfOrdinaryBiologicalObject The ClassOfStateOfOrdinaryBiologicalObject.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -133,9 +155,12 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -143,9 +168,17 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -154,9 +187,12 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryBiologicalObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -165,11 +201,13 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_ordinary_biological_object may be a
-         * temporal_part_of one or more {@link OrdinaryBiologicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfOrdinaryBiologicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryBiologicalObject}.
          *
-         * @param ordinaryBiologicalObject
-         * @return
+         * @param ordinaryBiologicalObject The OrdinaryBiologicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final OrdinaryBiologicalObject ordinaryBiologicalObject) {
@@ -179,9 +217,12 @@ public class StateOfOrdinaryBiologicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfOrdinaryBiologicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfOrdinaryBiologicalObject.
+         * @throws HqdmException If the StateOfOrdinaryBiologicalObject is missing any mandatory
+         *         properties.
          */
         public StateOfOrdinaryBiologicalObject build() throws HqdmException {
             if (stateOfOrdinaryBiologicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryFunctionalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryFunctionalObjectImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         implements StateOfOrdinaryFunctionalObject {
     /**
+     * Constructs a new StateOfOrdinaryFunctionalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfOrdinaryFunctionalObject.
      */
     public StateOfOrdinaryFunctionalObjectImpl(final IRI iri) {
         super(StateOfOrdinaryFunctionalObjectImpl.class, iri, STATE_OF_ORDINARY_FUNCTIONAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfOrdinaryFunctionalObjectImpl.
+     * Builder for constructing instances of StateOfOrdinaryFunctionalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfOrdinaryFunctionalObjectImpl stateOfOrdinaryFunctionalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfOrdinaryFunctionalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfOrdinaryFunctionalObject.
          */
         public Builder(final IRI iri) {
             stateOfOrdinaryFunctionalObjectImpl = new StateOfOrdinaryFunctionalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(AGGREGATED_INTO,
@@ -77,9 +85,11 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(CONSISTS__OF,
@@ -98,9 +114,11 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(ENDING, event.getIri());
@@ -108,9 +126,11 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -118,11 +138,13 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_ordinary_functional_object may be a
-         * member_of one or more {@link ClassOfStateOfOrdinaryFunctionalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfOrdinaryFunctionalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrdinaryFunctionalObject}.
          *
-         * @param classOfStateOfOrdinaryFunctionalObject
-         * @return
+         * @param classOfStateOfOrdinaryFunctionalObject The ClassOfStateOfOrdinaryFunctionalObject.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -133,9 +155,12 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -143,9 +168,17 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -154,9 +187,12 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryFunctionalObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -165,11 +201,12 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_ordinary_functional_object may be a
-         * temporal part of one or more {@link OrdinaryFunctionalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfOrdinaryFunctionalObject} may be a temporal part of one or more
+         * {@link OrdinaryFunctionalObject}.
          *
-         * @param ordinaryFunctionalObject
-         * @return
+         * @param ordinaryFunctionalObject The OrdinaryFunctionalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final OrdinaryFunctionalObject ordinaryFunctionalObject) {
@@ -179,9 +216,12 @@ public class StateOfOrdinaryFunctionalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfOrdinaryFunctionalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfOrdinaryFunctionalObject.
+         * @throws HqdmException If the StateOfOrdinaryFunctionalObject is missing any mandatory
+         *         properties.
          */
         public StateOfOrdinaryFunctionalObject build() throws HqdmException {
             if (stateOfOrdinaryFunctionalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrdinaryPhysicalObjectImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         implements StateOfOrdinaryPhysicalObject {
     /**
+     * Constructs a new StateOfOrdinaryPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfOrdinaryPhysicalObject.
      */
     public StateOfOrdinaryPhysicalObjectImpl(final IRI iri) {
         super(StateOfOrdinaryPhysicalObjectImpl.class, iri, STATE_OF_ORDINARY_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfOrdinaryPhysicalObjectImpl.
+     * Builder for constructing instances of StateOfOrdinaryPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfOrdinaryPhysicalObjectImpl stateOfOrdinaryPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfOrdinaryPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfOrdinaryPhysicalObject.
          */
         public Builder(final IRI iri) {
             stateOfOrdinaryPhysicalObjectImpl = new StateOfOrdinaryPhysicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(AGGREGATED_INTO,
@@ -77,9 +85,11 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,13 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_ordinary_physical_object may be a
-         * member_of one or more {@link ClassOfStateOfOrdinaryPhysicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfOrdinaryPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfOrdinaryPhysicalObject}.
          *
-         * @param classOfStateOfOrdinaryPhysicalObject
-         * @return
+         * @param classOfStateOfOrdinaryPhysicalObject The ClassOfStateOfOrdinaryPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrdinaryPhysicalObject classOfStateOfOrdinaryPhysicalObject) {
@@ -131,9 +153,12 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -141,9 +166,17 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -152,9 +185,12 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -163,11 +199,13 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_ordinary_physical_object may be a
-         * temporal_part_of one or more {@link OrdinaryPhysicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfOrdinaryPhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrdinaryPhysicalObject}.
          *
-         * @param ordinaryPhysicalObject
-         * @return
+         * @param ordinaryPhysicalObject The OrdinaryPhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final OrdinaryPhysicalObject ordinaryPhysicalObject) {
             stateOfOrdinaryPhysicalObjectImpl.addValue(TEMPORAL_PART_OF,
@@ -176,9 +214,12 @@ public class StateOfOrdinaryPhysicalObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfOrdinaryPhysicalObject created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfOrdinaryPhysicalObject.
+         * @throws HqdmException If the StateOfOrdinaryPhysicalObject is missing any mandatory
+         *         properties.
          */
         public StateOfOrdinaryPhysicalObject build() throws HqdmException {
             if (stateOfOrdinaryPhysicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrganizationComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrganizationComponentImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfOrganizationComponentImpl extends HqdmObject
         implements StateOfOrganizationComponent {
     /**
+     * Constructs a new StateOfOrganizationComponent.
      *
-     * @param iri
+     * @param iri IRI of the StateOfOrganizationComponent.
      */
     public StateOfOrganizationComponentImpl(final IRI iri) {
         super(StateOfOrganizationComponentImpl.class, iri, STATE_OF_ORGANIZATION_COMPONENT);
     }
 
     /**
-     * Builder for StateOfOrganizationComponentImpl.
+     * Builder for constructing instances of StateOfOrganizationComponent.
      */
     public static class Builder {
-        /** */
+
         private final StateOfOrganizationComponentImpl stateOfOrganizationComponentImpl;
 
         /**
+         * Constructs a Builder for a new StateOfOrganizationComponent.
          *
-         * @param iri
+         * @param iri IRI of the StateOfOrganizationComponent.
          */
         public Builder(final IRI iri) {
             stateOfOrganizationComponentImpl = new StateOfOrganizationComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationComponentImpl.addValue(AGGREGATED_INTO,
@@ -77,9 +85,11 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfOrganizationComponentImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfOrganizationComponentImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfOrganizationComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_organization_component may be a member_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfOrganizationComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
          * one or more {@link ClassOfStateOfOrganizationComponent}.
          *
-         * @param classOfStateOfOrganizationComponent
-         * @return
+         * @param classOfStateOfOrganizationComponent The ClassOfStateOfOrganizationComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrganizationComponent classOfStateOfOrganizationComponent) {
@@ -131,9 +152,12 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -141,9 +165,17 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfOrganizationComponentImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -152,9 +184,12 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationComponentImpl.addValue(TEMPORAL__PART_OF,
@@ -163,11 +198,13 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_organization_component may be a
-         * temporal_part_of one or more {@link OrganizationComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfOrganizationComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link OrganizationComponent}.
          *
-         * @param organizationComponent
-         * @return
+         * @param organizationComponent The OrganizationComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final OrganizationComponent organizationComponent) {
             stateOfOrganizationComponentImpl.addValue(TEMPORAL_PART_OF,
@@ -176,9 +213,12 @@ public class StateOfOrganizationComponentImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfOrganizationComponent created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfOrganizationComponent.
+         * @throws HqdmException If the StateOfOrganizationComponent is missing any mandatory
+         *         properties.
          */
         public StateOfOrganizationComponent build() throws HqdmException {
             if (stateOfOrganizationComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrganizationImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfOrganizationImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrganization {
     /**
+     * Constructs a new StateOfOrganization.
      *
-     * @param iri
+     * @param iri IRI of the StateOfOrganization.
      */
     public StateOfOrganizationImpl(final IRI iri) {
         super(StateOfOrganizationImpl.class, iri, STATE_OF_ORGANIZATION);
     }
 
     /**
-     * Builder for StateOfOrganizationImpl.
+     * Builder for constructing instances of StateOfOrganization.
      */
     public static class Builder {
-        /** */
+
         private final StateOfOrganizationImpl stateOfOrganizationImpl;
 
         /**
+         * Constructs a Builder for a new StateOfOrganization.
          *
-         * @param iri
+         * @param iri IRI of the StateOfOrganization.
          */
         public Builder(final IRI iri) {
             stateOfOrganizationImpl = new StateOfOrganizationImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfOrganizationImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfOrganizationImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfOrganizationImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
-         * A member_of relationship type where a state_of_organization may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfOrganization} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfStateOfOrganization}.
          *
-         * @param classOfStateOfOrganization
-         * @return
+         * @param classOfStateOfOrganization The ClassOfStateOfOrganization.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfOrganization classOfStateOfOrganization) {
@@ -128,9 +149,12 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -138,9 +162,17 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfOrganizationImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -148,9 +180,12 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfOrganizationImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -158,11 +193,12 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_organization may be a
-         * temporal_part_of one or more {@link Organization}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfOrganization} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF}
+         * one or more {@link Organization}.
          *
-         * @param organization
-         * @return
+         * @param organization The Organization.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Organization organization) {
             stateOfOrganizationImpl.addValue(TEMPORAL_PART_OF, organization.getIri());
@@ -170,9 +206,11 @@ public class StateOfOrganizationImpl extends HqdmObject implements StateOfOrgani
         }
 
         /**
+         * Returns an instance of StateOfOrganization created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfOrganization.
+         * @throws HqdmException If the StateOfOrganization is missing any mandatory properties.
          */
         public StateOfOrganization build() throws HqdmException {
             if (stateOfOrganizationImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPartyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPartyImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
     /**
+     * Constructs a new StateOfParty.
      *
-     * @param iri
+     * @param iri IRI of the StateOfParty.
      */
     public StateOfPartyImpl(final IRI iri) {
         super(StateOfPartyImpl.class, iri, STATE_OF_PARTY);
     }
 
     /**
-     * Builder for StateOfPartyImpl.
+     * Builder for constructing instances of StateOfParty.
      */
     public static class Builder {
-        /** */
+
         private final StateOfPartyImpl stateOfPartyImpl;
 
         /**
+         * Constructs a Builder for a new StateOfParty.
          *
-         * @param iri
+         * @param iri IRI of the StateOfParty.
          */
         public Builder(final IRI iri) {
             stateOfPartyImpl = new StateOfPartyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPartyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfPartyImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPartyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfPartyImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfPartyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
-         * A member_of relationship type where a state_of_party may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfParty} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfParty}.
          *
-         * @param classOfStateOfParty
-         * @return
+         * @param classOfStateOfParty The ClassOfStateOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfParty classOfStateOfParty) {
             stateOfPartyImpl.addValue(MEMBER_OF, classOfStateOfParty.getIri());
@@ -127,9 +148,12 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPartyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfPartyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPartyImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_party may be a temporal_part_of one
-         * or more {@link Party}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfParty} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or
+         * more {@link Party}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Party party) {
             stateOfPartyImpl.addValue(TEMPORAL_PART_OF, party.getIri());
@@ -169,9 +205,10 @@ public class StateOfPartyImpl extends HqdmObject implements StateOfParty {
         }
 
         /**
+         * Returns an instance of StateOfParty created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfParty.
+         * @throws HqdmException If the StateOfParty is missing any mandatory properties.
          */
         public StateOfParty build() throws HqdmException {
             if (stateOfPartyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPersonImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPersonImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
     /**
+     * Constructs a new StateOfPerson.
      *
-     * @param iri
+     * @param iri IRI of the StateOfPerson.
      */
     public StateOfPersonImpl(final IRI iri) {
         super(StateOfPersonImpl.class, iri, STATE_OF_PERSON);
     }
 
     /**
-     * Builder for StateOfPersonImpl.
+     * Builder for constructing instances of StateOfPerson.
      */
     public static class Builder {
-        /** */
+
         private final StateOfPersonImpl stateOfPersonImpl;
 
         /**
+         * Constructs a Builder for a new StateOfPerson.
          *
-         * @param iri
+         * @param iri IRI of the StateOfPerson.
          */
         public Builder(final IRI iri) {
             stateOfPersonImpl = new StateOfPersonImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPersonImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfPersonImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPersonImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfPersonImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfPersonImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
-         * A member_of relationship type where a state_of_person may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfPerson} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfPerson}.
          *
-         * @param classOfStateOfPerson
-         * @return
+         * @param classOfStateOfPerson The ClassOfStateOfPerson.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfPerson classOfStateOfPerson) {
             stateOfPersonImpl.addValue(MEMBER_OF, classOfStateOfPerson.getIri());
@@ -127,9 +148,12 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPersonImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfPersonImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPersonImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_person may be a temporal_part_of
-         * one or more {@link Person}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfPerson} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or
+         * more {@link Person}.
          *
-         * @param person
-         * @return
+         * @param person The Person.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Person person) {
             stateOfPersonImpl.addValue(TEMPORAL_PART_OF, person.getIri());
@@ -169,9 +205,10 @@ public class StateOfPersonImpl extends HqdmObject implements StateOfPerson {
         }
 
         /**
+         * Returns an instance of StateOfPerson created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfPerson.
+         * @throws HqdmException If the StateOfPerson is missing any mandatory properties.
          */
         public StateOfPerson build() throws HqdmException {
             if (stateOfPersonImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPhysicalObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPhysicalObjectImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhysicalObject {
     /**
+     * Constructs a new StateOfPhysicalObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfPhysicalObject.
      */
     public StateOfPhysicalObjectImpl(final IRI iri) {
         super(StateOfPhysicalObjectImpl.class, iri, STATE_OF_PHYSICAL_OBJECT);
     }
 
     /**
-     * Builder for StateOfPhysicalObjectImpl.
+     * Builder for constructing instances of StateOfPhysicalObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfPhysicalObjectImpl stateOfPhysicalObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfPhysicalObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfPhysicalObject.
          */
         public Builder(final IRI iri) {
             stateOfPhysicalObjectImpl = new StateOfPhysicalObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPhysicalObjectImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfPhysicalObjectImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPhysicalObjectImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfPhysicalObjectImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfPhysicalObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
-         * A member_of relationship type where a state_of_physical_object may be a member_of one or
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfPhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or
          * more {@link ClassOfStateOfPhysicalObject}.
          *
-         * @param classOfStateOfPhysicalObject
-         * @return
+         * @param classOfStateOfPhysicalObject The ClassOfStateOfPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfPhysicalObject classOfStateOfPhysicalObject) {
@@ -128,9 +149,12 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPhysicalObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -138,9 +162,17 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfPhysicalObjectImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -148,9 +180,12 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPhysicalObjectImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -158,11 +193,12 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_physical_object may be a
-         * temporal_part_of one or more {@link PhysicalObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfPhysicalObject} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF}
+         * one or more {@link PhysicalObject}.
          *
-         * @param physicalObject
-         * @return
+         * @param physicalObject The PhysicalObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final PhysicalObject physicalObject) {
             stateOfPhysicalObjectImpl.addValue(TEMPORAL_PART_OF, physicalObject.getIri());
@@ -170,9 +206,11 @@ public class StateOfPhysicalObjectImpl extends HqdmObject implements StateOfPhys
         }
 
         /**
+         * Returns an instance of StateOfPhysicalObject created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfPhysicalObject.
+         * @throws HqdmException If the StateOfPhysicalObject is missing any mandatory properties.
          */
         public StateOfPhysicalObject build() throws HqdmException {
             if (stateOfPhysicalObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfPositionImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
     /**
+     * Constructs a new StateOfPosition.
      *
-     * @param iri
+     * @param iri IRI of the StateOfPosition.
      */
     public StateOfPositionImpl(final IRI iri) {
         super(StateOfPositionImpl.class, iri, STATE_OF_POSITION);
     }
 
     /**
-     * Builder for StateOfPositionImpl.
+     * Builder for constructing instances of StateOfPosition.
      */
     public static class Builder {
-        /** */
+
         private final StateOfPositionImpl stateOfPositionImpl;
 
         /**
+         * Constructs a Builder for a new StateOfPosition.
          *
-         * @param iri
+         * @param iri IRI of the StateOfPosition.
          */
         public Builder(final IRI iri) {
             stateOfPositionImpl = new StateOfPositionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPositionImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfPositionImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPositionImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfPositionImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfPositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
-         * A member_of relationship type where a state_of_position may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfPosition} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfPosition}.
          *
-         * @param classOfStateOfPosition
-         * @return
+         * @param classOfStateOfPosition The ClassOfStateOfPosition.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfPosition classOfStateOfPosition) {
             stateOfPositionImpl.addValue(MEMBER_OF, classOfStateOfPosition.getIri());
@@ -127,9 +148,12 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPositionImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfPositionImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfPositionImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_position may be a temporal_part_of
-         * one or more {@link Position}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfPosition} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one
+         * or more {@link Position}.
          *
-         * @param position
-         * @return
+         * @param position The Position.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Position position) {
             stateOfPositionImpl.addValue(TEMPORAL_PART_OF, position.getIri());
@@ -169,9 +205,10 @@ public class StateOfPositionImpl extends HqdmObject implements StateOfPosition {
         }
 
         /**
+         * Returns an instance of StateOfPosition created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfPosition.
+         * @throws HqdmException If the StateOfPosition is missing any mandatory properties.
          */
         public StateOfPosition build() throws HqdmException {
             if (stateOfPositionImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSalesProductInstanceImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSalesProductInstanceImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfSalesProductInstanceImpl extends HqdmObject
         implements StateOfSalesProductInstance {
     /**
+     * Constructs a new StateOfSalesProductInstance.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSalesProductInstance.
      */
     public StateOfSalesProductInstanceImpl(final IRI iri) {
         super(StateOfSalesProductInstanceImpl.class, iri, STATE_OF_SALES_PRODUCT_INSTANCE);
     }
 
     /**
-     * Builder for StateOfSalesProductInstanceImpl.
+     * Builder for constructing instances of StateOfSalesProductInstance.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSalesProductInstanceImpl stateOfSalesProductInstanceImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSalesProductInstance.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSalesProductInstance.
          */
         public Builder(final IRI iri) {
             stateOfSalesProductInstanceImpl = new StateOfSalesProductInstanceImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSalesProductInstanceImpl.addValue(AGGREGATED_INTO,
@@ -77,9 +85,11 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSalesProductInstanceImpl.addValue(BEGINNING, event.getIri());
@@ -87,9 +97,15 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSalesProductInstanceImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -97,9 +113,11 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSalesProductInstanceImpl.addValue(ENDING, event.getIri());
@@ -107,9 +125,11 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSalesProductInstanceImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -117,11 +137,12 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_sales_product_instance may be a member_of
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfSalesProductInstance} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF}
          * one or more {@link ClassOfStateOfSalesProductInstance}.
          *
-         * @param classOfStateOfSalesProductInstance
-         * @return
+         * @param classOfStateOfSalesProductInstance The ClassOfStateOfSalesProductInstance.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfSalesProductInstance classOfStateOfSalesProductInstance) {
@@ -131,9 +152,12 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSalesProductInstanceImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -141,9 +165,17 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSalesProductInstanceImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -152,9 +184,12 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSalesProductInstanceImpl.addValue(TEMPORAL__PART_OF,
@@ -163,11 +198,13 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_sales_product_instance may be a
-         * temporal_part_of one or more {@link SalesProductInstance}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfSalesProductInstance} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link SalesProductInstance}.
          *
-         * @param salesProductInstance
-         * @return
+         * @param salesProductInstance The SalesProductInstance.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final SalesProductInstance salesProductInstance) {
             stateOfSalesProductInstanceImpl.addValue(TEMPORAL_PART_OF,
@@ -176,9 +213,12 @@ public class StateOfSalesProductInstanceImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfSalesProductInstance created from the properties set on
+         * this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSalesProductInstance.
+         * @throws HqdmException If the StateOfSalesProductInstance is missing any mandatory
+         *         properties.
          */
         public StateOfSalesProductInstance build() throws HqdmException {
             if (stateOfSalesProductInstanceImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSignImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSignImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfSignImpl extends HqdmObject implements StateOfSign {
     /**
+     * Constructs a new StateOfSign.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSign.
      */
     public StateOfSignImpl(final IRI iri) {
         super(StateOfSignImpl.class, iri, STATE_OF_SIGN);
     }
 
     /**
-     * Builder for StateOfSignImpl.
+     * Builder for constructing instances of StateOfSign.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSignImpl stateOfSignImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSign.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSign.
          */
         public Builder(final IRI iri) {
             stateOfSignImpl = new StateOfSignImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSignImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSignImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSignImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSignImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSignImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
-         * A member_of relationship type where a state_of_sign may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfSign} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfSign}.
          *
-         * @param classOfStateOfSign
-         * @return
+         * @param classOfStateOfSign The ClassOfStateOfSign.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfSign classOfStateOfSign) {
             stateOfSignImpl.addValue(MEMBER_OF, classOfStateOfSign.getIri());
@@ -127,9 +148,12 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSignImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSignImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSignImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_sign may be a temporal_part_of one
-         * or more {@link Sign}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfSign} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or
+         * more {@link Sign}.
          *
-         * @param sign
-         * @return
+         * @param sign The Sign.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Sign sign) {
             stateOfSignImpl.addValue(TEMPORAL_PART_OF, sign.getIri());
@@ -169,9 +205,10 @@ public class StateOfSignImpl extends HqdmObject implements StateOfSign {
         }
 
         /**
+         * Returns an instance of StateOfSign created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSign.
+         * @throws HqdmException If the StateOfSign is missing any mandatory properties.
          */
         public StateOfSign build() throws HqdmException {
             if (stateOfSignImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSociallyConstructedActivityImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSociallyConstructedActivityImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         implements StateOfSociallyConstructedActivity {
     /**
+     * Constructs a new StateOfSociallyConstructedActivity.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSociallyConstructedActivity.
      */
     public StateOfSociallyConstructedActivityImpl(final IRI iri) {
         super(StateOfSociallyConstructedActivityImpl.class, iri,
@@ -52,15 +53,16 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
     }
 
     /**
-     * Builder for StateOfSociallyConstructedActivityImpl.
+     * Builder for constructing instances of StateOfSociallyConstructedActivity.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSociallyConstructedActivityImpl stateOfSociallyConstructedActivityImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSociallyConstructedActivity.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSociallyConstructedActivity.
          */
         public Builder(final IRI iri) {
             stateOfSociallyConstructedActivityImpl =
@@ -68,9 +70,15 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedActivityImpl.addValue(AGGREGATED_INTO,
@@ -79,9 +87,11 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSociallyConstructedActivityImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedActivityImpl.addValue(CONSISTS__OF,
@@ -100,9 +116,11 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSociallyConstructedActivityImpl.addValue(ENDING, event.getIri());
@@ -110,9 +128,11 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSociallyConstructedActivityImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -120,9 +140,14 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfSociallyConstructedObject}.
          *
-         * @param classOfStateOfSociallyConstructedObject
-         * @return
+         * @param classOfStateOfSociallyConstructedObject The
+         *        classOfStateOfSociallyConstructedObject.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -133,9 +158,12 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedActivityImpl.addValue(PART__OF,
@@ -144,9 +172,17 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSociallyConstructedActivityImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -155,9 +191,12 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedActivityImpl.addValue(TEMPORAL__PART_OF,
@@ -166,9 +205,13 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfSociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link SociallyConstructedObject}.
          *
-         * @param sociallyConstructedObject
-         * @return
+         * @param sociallyConstructedObject The SociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final SociallyConstructedObject sociallyConstructedObject) {
@@ -178,9 +221,12 @@ public class StateOfSociallyConstructedActivityImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfSociallyConstructedActivity created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSociallyConstructedActivity.
+         * @throws HqdmException If the StateOfSociallyConstructedActivity is missing any mandatory
+         *         properties.
          */
         public StateOfSociallyConstructedActivity build() throws HqdmException {
             if (stateOfSociallyConstructedActivityImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSociallyConstructedObjectImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSociallyConstructedObjectImpl.java
@@ -43,8 +43,9 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         implements StateOfSociallyConstructedObject {
     /**
+     * Constructs a new StateOfSociallyConstructedObject.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSociallyConstructedObject.
      */
     public StateOfSociallyConstructedObjectImpl(final IRI iri) {
         super(StateOfSociallyConstructedObjectImpl.class, iri,
@@ -52,24 +53,31 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
     }
 
     /**
-     * Builder for StateOfSociallyConstructedObjectImpl.
+     * Builder for constructing instances of StateOfSociallyConstructedObject.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSociallyConstructedObjectImpl stateOfSociallyConstructedObjectImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSociallyConstructedObject.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSociallyConstructedObject.
          */
         public Builder(final IRI iri) {
             stateOfSociallyConstructedObjectImpl = new StateOfSociallyConstructedObjectImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedObjectImpl.addValue(AGGREGATED_INTO,
@@ -78,9 +86,11 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSociallyConstructedObjectImpl.addValue(BEGINNING, event.getIri());
@@ -88,9 +98,15 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedObjectImpl.addValue(CONSISTS__OF,
@@ -99,9 +115,11 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSociallyConstructedObjectImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSociallyConstructedObjectImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,11 +139,14 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A member_of relationship type where a state_of_socially_constructed_object may be a
-         * member_of one or more {@link ClassOfStateOfSociallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfSociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfStateOfSociallyConstructedObject}.
          *
-         * @param classOfStateOfSociallyConstructedObject
-         * @return
+         * @param classOfStateOfSociallyConstructedObject The
+         *        classOfStateOfSociallyConstructedObject.
+         * @return This builder.
          */
         @SuppressWarnings("LineLength")
         public final Builder member_Of(
@@ -134,9 +157,12 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedObjectImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -144,9 +170,17 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSociallyConstructedObjectImpl.addValue(PART_OF_POSSIBLE_WORLD,
@@ -155,9 +189,12 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSociallyConstructedObjectImpl.addValue(TEMPORAL__PART_OF,
@@ -166,11 +203,13 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_socially_constructed_object may be
-         * a temporal_part_of one or more {@link SociallyConstructedObject}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfSociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more
+         * {@link SociallyConstructedObject}.
          *
-         * @param sociallyConstructedObject
-         * @return
+         * @param sociallyConstructedObject The SociallyConstructedObject.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(
                 final SociallyConstructedObject sociallyConstructedObject) {
@@ -180,9 +219,12 @@ public class StateOfSociallyConstructedObjectImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of StateOfSociallyConstructedObject created from the properties set
+         * on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSociallyConstructedObject.
+         * @throws HqdmException If the StateOfSociallyConstructedObject is missing any mandatory
+         *         properties.
          */
         public StateOfSociallyConstructedObject build() throws HqdmException {
             if (stateOfSociallyConstructedObjectImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSystemComponentImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSystemComponent {
     /**
+     * Constructs a new StateOfSystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSystemComponent.
      */
     public StateOfSystemComponentImpl(final IRI iri) {
         super(StateOfSystemComponentImpl.class, iri, STATE_OF_SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for StateOfSystemComponentImpl.
+     * Builder for constructing instances of StateOfSystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSystemComponentImpl stateOfSystemComponentImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSystemComponent.
          */
         public Builder(final IRI iri) {
             stateOfSystemComponentImpl = new StateOfSystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSystemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSystemComponentImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSystemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
-         * A member_of relationship type where a state_of_system_component may be a member_of one or
-         * more {@link ClassOfStateOfSystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfSystemComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one
+         * or more {@link ClassOfStateOfSystemComponent}.
          *
-         * @param classOfStateOfSystemComponent
-         * @return
+         * @param classOfStateOfSystemComponent The ClassOfStateOfSystemComponent.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfStateOfSystemComponent classOfStateOfSystemComponent) {
@@ -128,9 +149,12 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -138,9 +162,17 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSystemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -148,9 +180,12 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemComponentImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -158,11 +193,12 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_system_component may be a
-         * temporal_part_of one or more {@link SystemComponent}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfSystemComponent} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link SystemComponent}.
          *
-         * @param systemComponent
-         * @return
+         * @param systemComponent The SystemComponent.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final SystemComponent systemComponent) {
             stateOfSystemComponentImpl.addValue(TEMPORAL_PART_OF, systemComponent.getIri());
@@ -170,9 +206,11 @@ public class StateOfSystemComponentImpl extends HqdmObject implements StateOfSys
         }
 
         /**
+         * Returns an instance of StateOfSystemComponent created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSystemComponent.
+         * @throws HqdmException If the StateOfSystemComponent is missing any mandatory properties.
          */
         public StateOfSystemComponent build() throws HqdmException {
             if (stateOfSystemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/StateOfSystemImpl.java
@@ -42,32 +42,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
     /**
+     * Constructs a new StateOfSystem.
      *
-     * @param iri
+     * @param iri IRI of the StateOfSystem.
      */
     public StateOfSystemImpl(final IRI iri) {
         super(StateOfSystemImpl.class, iri, STATE_OF_SYSTEM);
     }
 
     /**
-     * Builder for StateOfSystemImpl.
+     * Builder for constructing instances of StateOfSystem.
      */
     public static class Builder {
-        /** */
+
         private final StateOfSystemImpl stateOfSystemImpl;
 
         /**
+         * Constructs a Builder for a new StateOfSystem.
          *
-         * @param iri
+         * @param iri IRI of the StateOfSystem.
          */
         public Builder(final IRI iri) {
             stateOfSystemImpl = new StateOfSystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -75,9 +83,11 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             stateOfSystemImpl.addValue(BEGINNING, event.getIri());
@@ -85,9 +95,15 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -95,9 +111,11 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             stateOfSystemImpl.addValue(ENDING, event.getIri());
@@ -105,9 +123,11 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             stateOfSystemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -115,11 +135,12 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
-         * A member_of relationship type where a state_of_system may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link StateOfSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfStateOfSystem}.
          *
-         * @param classOfStateOfSystem
-         * @return
+         * @param classOfStateOfSystem The ClassOfStateOfSystem.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfSystem classOfStateOfSystem) {
             stateOfSystemImpl.addValue(MEMBER_OF, classOfStateOfSystem.getIri());
@@ -127,9 +148,12 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -137,9 +161,17 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             stateOfSystemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -147,9 +179,12 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             stateOfSystemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -157,11 +192,12 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
-         * A temporal_part_of relationship type where a state_of_system may be a temporal_part_of
-         * one or more {@link System}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link StateOfSystem} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or
+         * more {@link System}.
          *
-         * @param system
-         * @return
+         * @param system The System.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final System system) {
             stateOfSystemImpl.addValue(TEMPORAL_PART_OF, system.getIri());
@@ -169,9 +205,10 @@ public class StateOfSystemImpl extends HqdmObject implements StateOfSystem {
         }
 
         /**
+         * Returns an instance of StateOfSystem created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built StateOfSystem.
+         * @throws HqdmException If the StateOfSystem is missing any mandatory properties.
          */
         public StateOfSystem build() throws HqdmException {
             if (stateOfSystemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SystemComponentImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SystemComponentImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SystemComponentImpl extends HqdmObject implements SystemComponent {
     /**
+     * Constructs a new SystemComponent.
      *
-     * @param iri
+     * @param iri IRI of the SystemComponent.
      */
     public SystemComponentImpl(final IRI iri) {
         super(SystemComponentImpl.class, iri, SYSTEM_COMPONENT);
     }
 
     /**
-     * Builder for SystemComponentImpl.
+     * Builder for constructing instances of SystemComponent.
      */
     public static class Builder {
-        /** */
+
         private final SystemComponentImpl systemComponentImpl;
 
         /**
+         * Constructs a Builder for a new SystemComponent.
          *
-         * @param iri
+         * @param iri IRI of the SystemComponent.
          */
         public Builder(final IRI iri) {
             systemComponentImpl = new SystemComponentImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             systemComponentImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             systemComponentImpl.addValue(BEGINNING, event.getIri());
@@ -89,11 +99,12 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
-         * A part_of relationship type where each system_component is part_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where each
+         * {@link SystemComponent} is {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} exactly one
          * {@link System}.
          *
-         * @param system
-         * @return
+         * @param system The System.
+         * @return This builder.
          */
         public final Builder component_Of_M(final System system) {
             systemComponentImpl.addValue(COMPONENT_OF, system.getIri());
@@ -101,9 +112,15 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemComponentImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -111,9 +128,11 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             systemComponentImpl.addValue(ENDING, event.getIri());
@@ -121,9 +140,11 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             systemComponentImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -131,11 +152,12 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
-         * A member_of relationship type where a system_component may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link SystemComponent} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link ClassOfSystemComponent}.
          *
-         * @param classOfSystemComponent
-         * @return
+         * @param classOfSystemComponent The ClassOfSystemComponent.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfSystemComponent classOfSystemComponent) {
             systemComponentImpl.addValue(MEMBER_OF, classOfSystemComponent.getIri());
@@ -143,9 +165,12 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.PhysicalObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link KindOfPhysicalObject}.
          *
-         * @param kindOfPhysicalObject
-         * @return
+         * @param kindOfPhysicalObject The KindOfPhysicalObject.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfPhysicalObject kindOfPhysicalObject) {
             systemComponentImpl.addValue(MEMBER_OF_KIND, kindOfPhysicalObject.getIri());
@@ -153,9 +178,12 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemComponentImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -163,9 +191,17 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             systemComponentImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -173,9 +209,12 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemComponentImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -183,9 +222,21 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             systemComponentImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -193,9 +244,10 @@ public class SystemComponentImpl extends HqdmObject implements SystemComponent {
         }
 
         /**
+         * Returns an instance of SystemComponent created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built SystemComponent.
+         * @throws HqdmException If the SystemComponent is missing any mandatory properties.
          */
         public SystemComponent build() throws HqdmException {
             if (systemComponentImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/SystemImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/SystemImpl.java
@@ -43,32 +43,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class SystemImpl extends HqdmObject implements System {
     /**
+     * Constructs a new System.
      *
-     * @param iri
+     * @param iri IRI of the System.
      */
     public SystemImpl(final IRI iri) {
         super(SystemImpl.class, iri, SYSTEM);
     }
 
     /**
-     * Builder for SystemImpl.
+     * Builder for constructing instances of System.
      */
     public static class Builder {
-        /** */
+
         private final SystemImpl systemImpl;
 
         /**
+         * Constructs a Builder for a new System.
          *
-         * @param iri
+         * @param iri IRI of the System.
          */
         public Builder(final IRI iri) {
             systemImpl = new SystemImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             systemImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -76,9 +84,11 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             systemImpl.addValue(BEGINNING, event.getIri());
@@ -86,9 +96,15 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -96,9 +112,11 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             systemImpl.addValue(ENDING, event.getIri());
@@ -106,9 +124,11 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             systemImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -116,11 +136,11 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
-         * A member_of relationship type where a system may be a member_of one or more
-         * {@link ClassOfSystem}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a {@link System}
+         * may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfSystem}.
          *
-         * @param classOfSystem
-         * @return
+         * @param classOfSystem The ClassOfSystem.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfSystem classOfSystem) {
             systemImpl.addValue(MEMBER_OF, classOfSystem.getIri());
@@ -128,11 +148,12 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
-         * A member_of_kind relationship type where a system may be a member_of one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where a
+         * {@link System} may be a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
          * {@link KindOfSystem}.
          *
-         * @param kindOfSystem
-         * @return
+         * @param kindOfSystem The KindOfSystem.
+         * @return This builder.
          */
         public final Builder member_Of_Kind(final KindOfSystem kindOfSystem) {
             systemImpl.addValue(MEMBER_OF_KIND, kindOfSystem.getIri());
@@ -140,9 +161,12 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -150,9 +174,17 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             systemImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -160,9 +192,12 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             systemImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -170,9 +205,12 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfSystem} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link System}.
          *
-         * @param system
-         * @return
+         * @param system The System.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final System system) {
             systemImpl.addValue(TEMPORAL_PART_OF, system.getIri());
@@ -180,9 +218,10 @@ public class SystemImpl extends HqdmObject implements System {
         }
 
         /**
+         * Returns an instance of System created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built System.
+         * @throws HqdmException If the System is missing any mandatory properties.
          */
         public System build() throws HqdmException {
             if (systemImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/TemporalCompositionImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/TemporalCompositionImpl.java
@@ -33,32 +33,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class TemporalCompositionImpl extends HqdmObject implements TemporalComposition {
     /**
+     * Constructs a new TemporalComposition.
      *
-     * @param iri
+     * @param iri IRI of the TemporalComposition.
      */
     public TemporalCompositionImpl(final IRI iri) {
         super(TemporalCompositionImpl.class, iri, TEMPORAL_COMPOSITION);
     }
 
     /**
-     * Builder for TemporalCompositionImpl.
+     * Builder for constructing instances of TemporalComposition.
      */
     public static class Builder {
-        /** */
+
         private final TemporalCompositionImpl temporalCompositionImpl;
 
         /**
+         * Constructs a Builder for a new TemporalComposition.
          *
-         * @param iri
+         * @param iri IRI of the TemporalComposition.
          */
         public Builder(final IRI iri) {
             temporalCompositionImpl = new TemporalCompositionImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             temporalCompositionImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -66,9 +70,11 @@ public class TemporalCompositionImpl extends HqdmObject implements TemporalCompo
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             temporalCompositionImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -76,9 +82,11 @@ public class TemporalCompositionImpl extends HqdmObject implements TemporalCompo
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the part.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part_M(final SpatioTemporalExtent spatioTemporalExtent) {
             temporalCompositionImpl.addValue(PART, spatioTemporalExtent.getIri());
@@ -86,9 +94,11 @@ public class TemporalCompositionImpl extends HqdmObject implements TemporalCompo
         }
 
         /**
+         * A relationship type where an {@link uk.gov.gchq.hqdm.model.Aggregation} has exactly one
+         * {@link SpatioTemporalExtent} as the whole.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder whole_M(final SpatioTemporalExtent spatioTemporalExtent) {
             temporalCompositionImpl.addValue(WHOLE, spatioTemporalExtent.getIri());
@@ -96,9 +106,11 @@ public class TemporalCompositionImpl extends HqdmObject implements TemporalCompo
         }
 
         /**
+         * Returns an instance of TemporalComposition created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built TemporalComposition.
+         * @throws HqdmException If the TemporalComposition is missing any mandatory properties.
          */
         public TemporalComposition build() throws HqdmException {
             if (temporalCompositionImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/ThingImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/ThingImpl.java
@@ -27,36 +27,41 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  * An implementation of Thing.
  */
 public class ThingImpl extends HqdmObject implements Thing {
+    /**
+     * Constructs a new Thing with no IRI.
+     */
     public ThingImpl() {}
 
     /**
+     * Constructs a new Thing.
      *
-     * @param iri
+     * @param iri IRI of the Thing.
      */
     public ThingImpl(final IRI iri) {
         super(ThingImpl.class, iri, THING);
     }
 
     /**
-     * Builder for ThingImpl.
+     * Builder for constructing instances of Thing.
      */
     public static class Builder {
-        /** */
+
         private final ThingImpl thing;
 
         /**
+         * Constructs a Builder for a new Thing.
          *
-         * @param iri
+         * @param iri IRI of the Thing.
          */
         public Builder(final IRI iri) {
             thing = new ThingImpl(iri);
         }
 
         /**
-         * A relationship type where a thing may be a member of one or more {@link Class}.
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz Class of the Thing.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             thing.addValue(MEMBER__OF, clazz.getIri());
@@ -64,9 +69,10 @@ public class ThingImpl extends HqdmObject implements Thing {
         }
 
         /**
+         * Returns an instance of Thing created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Thing.
+         * @throws HqdmException If the Thing is missing any mandatory properties.
          */
         public Thing build() throws HqdmException {
             if (thing.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferOfOwnershipImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferOfOwnershipImpl.java
@@ -63,32 +63,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwnership {
     /**
+     * Constructs a new TransferOfOwnership.
      *
-     * @param iri
+     * @param iri IRI of the TransferOfOwnership.
      */
     public TransferOfOwnershipImpl(final IRI iri) {
         super(TransferOfOwnershipImpl.class, iri, TRANSFER_OF_OWNERSHIP);
     }
 
     /**
-     * Builder for TransferOfOwnershipImpl.
+     * Builder for constructing instances of TransferOfOwnership.
      */
     public static class Builder {
-        /** */
+
         private final TransferOfOwnershipImpl transferOfOwnershipImpl;
 
         /**
+         * Constructs a Builder for a new TransferOfOwnership.
          *
-         * @param iri
+         * @param iri IRI of the TransferOfOwnership.
          */
         public Builder(final IRI iri) {
             transferOfOwnershipImpl = new TransferOfOwnershipImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -96,9 +104,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             transferOfOwnershipImpl.addValue(BEGINNING, event.getIri());
@@ -106,9 +116,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             transferOfOwnershipImpl.addValue(CAUSES, event.getIri());
@@ -116,11 +128,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A causes relationship type where a transfer_of_ownership causes exactly one
-         * {@link BeginningOfOwnership}.
+         * A causes relationship type where a {@link TransferOfOwnership}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CAUSES} exactly one {@link BeginningOfOwnership}.
          *
-         * @param beginningOfOwnership
-         * @return
+         * @param beginningOfOwnership The BeginningOfOwnership.
+         * @return This builder.
          */
         public final Builder causes_Beginning_M(final BeginningOfOwnership beginningOfOwnership) {
             transferOfOwnershipImpl.addValue(CAUSES_BEGINNING, beginningOfOwnership.getIri());
@@ -128,11 +140,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A causes relationship type where a transfer_of_ownership causes exactly one
+         * A causes relationship type where a {@link TransferOfOwnership} causes exactly one
          * {@link EndingOfOwnership}.
          *
-         * @param endingOfOwnership
-         * @return
+         * @param endingOfOwnership The EndingOfOwnership.
+         * @return This builder.
          */
         public final Builder causes_Ending_M(final EndingOfOwnership endingOfOwnership) {
             transferOfOwnershipImpl.addValue(CAUSES_ENDING, endingOfOwnership.getIri());
@@ -140,9 +152,15 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -150,9 +168,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             transferOfOwnershipImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -160,11 +181,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A consists_of_participant relationship type where a transfer_of_ownership
-         * consists_of_participant exactly one {@link Transferor}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where a
+         * {@link TransferOfOwnership} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT}
+         * exactly one {@link Transferor}.
          *
-         * @param transferor
-         * @return
+         * @param transferor The Transferor.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Transferor transferor) {
             transferOfOwnershipImpl.addValue(CONSISTS_OF_PARTICIPANT, transferor.getIri());
@@ -172,11 +194,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A consists_of_participant relationship type where a transfer_of_ownership
-         * consists_of_participant exactly one {@link Transferee}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where a
+         * {@link TransferOfOwnership} {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT}
+         * exactly one {@link Transferee}.
          *
-         * @param transferee
-         * @return
+         * @param transferee The Transferee.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant_(final Transferee transferee) {
             transferOfOwnershipImpl.addValue(CONSISTS_OF_PARTICIPANT_, transferee.getIri());
@@ -184,9 +207,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             transferOfOwnershipImpl.addValue(DETERMINES, thing.getIri());
@@ -194,9 +219,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             transferOfOwnershipImpl.addValue(ENDING, event.getIri());
@@ -204,9 +231,10 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             transferOfOwnershipImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -214,9 +242,13 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfSociallyConstructedActivity}.
          *
-         * @param classOfSociallyConstructedActivity
-         * @return
+         * @param classOfSociallyConstructedActivity The ClassOfSociallyConstructedActivity.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedActivity classOfSociallyConstructedActivity) {
@@ -226,9 +258,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             transferOfOwnershipImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -236,9 +271,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -246,11 +284,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A part_of relationship type where a transfer_of_ownership may be part_of not more than
-         * one {@link ExchangeOfGoodsAndMoney}.
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link TransferOfOwnership} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} not more
+         * than one {@link ExchangeOfGoodsAndMoney}.
          *
-         * @param exchangeOfGoodsAndMoney
-         * @return
+         * @param exchangeOfGoodsAndMoney The ExchangeOfGoodsAndMoney.
+         * @return This builder.
          */
         public final Builder part_Of(final ExchangeOfGoodsAndMoney exchangeOfGoodsAndMoney) {
             transferOfOwnershipImpl.addValue(PART_OF, exchangeOfGoodsAndMoney.getIri());
@@ -258,9 +297,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             transferOfOwnershipImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -268,9 +310,17 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             transferOfOwnershipImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -278,11 +328,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
-         * A references relationship type where a transfer_of_ownership references exactly one
+         * A references relationship type where a {@link TransferOfOwnership} references exactly one
          * {@link Asset}.
          *
-         * @param asset
-         * @return
+         * @param asset The Asset.
+         * @return This builder.
          */
         public final Builder references_M(final Asset asset) {
             transferOfOwnershipImpl.addValue(REFERENCES, asset.getIri());
@@ -290,9 +340,12 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -300,9 +353,21 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             transferOfOwnershipImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -310,9 +375,11 @@ public class TransferOfOwnershipImpl extends HqdmObject implements TransferOfOwn
         }
 
         /**
+         * Returns an instance of TransferOfOwnership created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built TransferOfOwnership.
+         * @throws HqdmException If the TransferOfOwnership is missing any mandatory properties.
          */
         public TransferOfOwnership build() throws HqdmException {
             if (transferOfOwnershipImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferOfOwnershipOfMoneyImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferOfOwnershipOfMoneyImpl.java
@@ -64,32 +64,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
 public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         implements TransferOfOwnershipOfMoney {
     /**
+     * Constructs a new TransferOfOwnershipOfMoney.
      *
-     * @param iri
+     * @param iri IRI of the TransferOfOwnershipOfMoney.
      */
     public TransferOfOwnershipOfMoneyImpl(final IRI iri) {
         super(TransferOfOwnershipOfMoneyImpl.class, iri, TRANSFER_OF_OWNERSHIP_OF_MONEY);
     }
 
     /**
-     * Builder for TransferOfOwnershipOfMoneyImpl.
+     * Builder for constructing instances of TransferOfOwnershipOfMoney.
      */
     public static class Builder {
-        /** */
+
         private final TransferOfOwnershipOfMoneyImpl transferOfOwnershipOfMoneyImpl;
 
         /**
+         * Constructs a Builder for a new TransferOfOwnershipOfMoney.
          *
-         * @param iri
+         * @param iri IRI of the TransferOfOwnershipOfMoney.
          */
         public Builder(final IRI iri) {
             transferOfOwnershipOfMoneyImpl = new TransferOfOwnershipOfMoneyImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipOfMoneyImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -97,9 +105,11 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             transferOfOwnershipOfMoneyImpl.addValue(BEGINNING, event.getIri());
@@ -107,9 +117,11 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where each {@link Activity} is the cause of one or more
+         * {@link Event}.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder causes_M(final Event event) {
             transferOfOwnershipOfMoneyImpl.addValue(CAUSES, event.getIri());
@@ -117,9 +129,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CAUSES} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CAUSES} exactly one {@link BeginningOfOwnership}.
          *
-         * @param beginningOfOwnership
-         * @return
+         * @param beginningOfOwnership The BeginningOfOwnership.
+         * @return This builder.
          */
         public final Builder causes_Beginning_M(final BeginningOfOwnership beginningOfOwnership) {
             transferOfOwnershipOfMoneyImpl.addValue(CAUSES_BEGINNING,
@@ -128,9 +143,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CAUSES} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership} causes exactly one
+         * {@link EndingOfOwnership}.
          *
-         * @param endingOfOwnership
-         * @return
+         * @param endingOfOwnership The EndingOfOwnership.
+         * @return This builder.
          */
         public final Builder causes_Ending_M(final EndingOfOwnership endingOfOwnership) {
             transferOfOwnershipOfMoneyImpl.addValue(CAUSES_ENDING, endingOfOwnership.getIri());
@@ -138,9 +156,15 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipOfMoneyImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -148,9 +172,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} relationship type where an
+         * {@link Activity} may {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF} one or more other
+         * {@link Activity}.
          *
-         * @param activity
-         * @return
+         * @param activity The Activity.
+         * @return This builder.
          */
         public final Builder consists_Of(final Activity activity) {
             transferOfOwnershipOfMoneyImpl.addValue(CONSISTS_OF, activity.getIri());
@@ -158,9 +185,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} exactly one {@link Transferor}.
          *
-         * @param transferor
-         * @return
+         * @param transferor The Transferor.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant(final Transferor transferor) {
             transferOfOwnershipOfMoneyImpl.addValue(CONSISTS_OF_PARTICIPANT, transferor.getIri());
@@ -168,9 +198,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.TransferOfOwnership}
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#CONSISTS_OF_PARTICIPANT} exactly one {@link Transferee}.
          *
-         * @param transferee
-         * @return
+         * @param transferee The Transferee.
+         * @return This builder.
          */
         public final Builder consists_Of_Participant_(final Transferee transferee) {
             transferOfOwnershipOfMoneyImpl.addValue(CONSISTS_OF_PARTICIPANT_, transferee.getIri());
@@ -178,9 +211,11 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where an {@link Activity} may determine one or more {@link Thing} to
+         * be the case.
          *
-         * @param thing
-         * @return
+         * @param thing The Thing.
+         * @return This builder.
          */
         public final Builder determines(final Thing thing) {
             transferOfOwnershipOfMoneyImpl.addValue(DETERMINES, thing.getIri());
@@ -188,9 +223,11 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             transferOfOwnershipOfMoneyImpl.addValue(ENDING, event.getIri());
@@ -198,9 +235,10 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A relationship type where a {@link Thing} may be a member of one or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             transferOfOwnershipOfMoneyImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -208,9 +246,13 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedActivity} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link ClassOfSociallyConstructedActivity}.
          *
-         * @param classOfSociallyConstructedActivity
-         * @return
+         * @param classOfSociallyConstructedActivity The ClassOfSociallyConstructedActivity.
+         * @return This builder.
          */
         public final Builder member_Of(
                 final ClassOfSociallyConstructedActivity classOfSociallyConstructedActivity) {
@@ -220,9 +262,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link Activity} is a {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more
+         * {@link KindOfActivity}.
          *
-         * @param kindOfActivity
-         * @return
+         * @param kindOfActivity The KindOfActivity.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final KindOfActivity kindOfActivity) {
             transferOfOwnershipOfMoneyImpl.addValue(MEMBER_OF_KIND, kindOfActivity.getIri());
@@ -230,9 +275,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipOfMoneyImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -240,11 +288,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
-         * A part_of relationship type where a transfer_of_ownership_of_money may be a part_of at
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link TransferOfOwnershipOfMoney}may be a {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} at
          * most one {@link ExchangeOfGoodsAndMoney}.
          *
-         * @param exchangeOfGoodsAndMoney
-         * @return
+         * @param exchangeOfGoodsAndMoney The ExchangeOfGoodsAndMoney.
+         * @return This builder.
          */
         public final Builder part_Of(final ExchangeOfGoodsAndMoney exchangeOfGoodsAndMoney) {
             transferOfOwnershipOfMoneyImpl.addValue(PART_OF, exchangeOfGoodsAndMoney.getIri());
@@ -252,9 +301,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.SociallyConstructedObject} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more {@link AgreementExecution}.
          *
-         * @param agreementExecution
-         * @return
+         * @param agreementExecution The AgreementExecution.
+         * @return This builder.
          */
         public final Builder part_Of_(final AgreementExecution agreementExecution) {
             transferOfOwnershipOfMoneyImpl.addValue(PART_OF_, agreementExecution.getIri());
@@ -262,9 +314,17 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             transferOfOwnershipOfMoneyImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -272,11 +332,11 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
-         * A references relationship type where a transfer_of_ownership_of_money references exactly
-         * one {@link MoneyAsset}.
+         * A references relationship type where a {@link TransferOfOwnershipOfMoney}references
+         * exactly one {@link MoneyAsset}.
          *
-         * @param moneyAsset
-         * @return
+         * @param moneyAsset The MoneyAsset.
+         * @return This builder.
          */
         public final Builder references_M(final MoneyAsset moneyAsset) {
             transferOfOwnershipOfMoneyImpl.addValue(REFERENCES, moneyAsset.getIri());
@@ -284,9 +344,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferOfOwnershipOfMoneyImpl.addValue(TEMPORAL__PART_OF,
@@ -295,9 +358,21 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.State} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Individual}.
          *
-         * @param individual
-         * @return
+         * <p>
+         * Note: The relationship is optional because an {@link Individual} is not necessarily a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} another {@link Individual}, yet is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} {@link uk.gov.gchq.hqdm.model.State} as well
+         * as {@link Individual}. This applies to all subtypes of
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} that are between a {@code state_of_X}
+         * and {@code X}.
+         * </p>
+         *
+         * @param individual The Individual.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Individual individual) {
             transferOfOwnershipOfMoneyImpl.addValue(TEMPORAL_PART_OF, individual.getIri());
@@ -305,9 +380,12 @@ public class TransferOfOwnershipOfMoneyImpl extends HqdmObject
         }
 
         /**
+         * Returns an instance of TransferOfOwnershipOfMoney created from the properties set on this
+         * builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built TransferOfOwnershipOfMoney.
+         * @throws HqdmException If the TransferOfOwnershipOfMoney is missing any mandatory
+         *         properties.
          */
         public TransferOfOwnershipOfMoney build() throws HqdmException {
             if (transferOfOwnershipOfMoneyImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/TransfereeImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/TransfereeImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class TransfereeImpl extends HqdmObject implements Transferee {
     /**
+     * Constructs a new Transferee.
      *
-     * @param iri
+     * @param iri IRI of the Transferee.
      */
     public TransfereeImpl(final IRI iri) {
         super(TransfereeImpl.class, iri, TRANSFEREE);
     }
 
     /**
-     * Builder for TransfereeImpl.
+     * Builder for constructing instances of Transferee.
      */
     public static class Builder {
-        /** */
+
         private final TransfereeImpl transfereeImpl;
 
         /**
+         * Constructs a Builder for a new Transferee.
          *
-         * @param iri
+         * @param iri IRI of the Transferee.
          */
         public Builder(final IRI iri) {
             transfereeImpl = new TransfereeImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             transfereeImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             transfereeImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transfereeImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             transfereeImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             transfereeImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfStateOfParty}.
          *
-         * @param classOfStateOfParty
-         * @return
+         * @param classOfStateOfParty The ClassOfStateOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfParty classOfStateOfParty) {
             transfereeImpl.addValue(MEMBER_OF, classOfStateOfParty.getIri());
@@ -129,9 +152,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             transfereeImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transfereeImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             transfereeImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
-         * A participant_in relationship type where a transferee is a participant_in one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where a
+         * {@link Transferee} is a {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} one or more
          * {@link TransferOfOwnership}.
          *
-         * @param transferOfOwnership
-         * @return
+         * @param transferOfOwnership The TransferOfOwnership.
+         * @return This builder.
          */
         public final Builder participant_In_M(final TransferOfOwnership transferOfOwnership) {
             transfereeImpl.addValue(PARTICIPANT_IN, transferOfOwnership.getIri());
@@ -171,9 +209,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transfereeImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,9 +222,12 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} one or more {@link Party}.
          *
-         * @param party
-         * @return
+         * @param party The Party.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Party party) {
             transfereeImpl.addValue(TEMPORAL_PART_OF, party.getIri());
@@ -191,9 +235,10 @@ public class TransfereeImpl extends HqdmObject implements Transferee {
         }
 
         /**
+         * Returns an instance of Transferee created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Transferee.
+         * @throws HqdmException If the Transferee is missing any mandatory properties.
          */
         public Transferee build() throws HqdmException {
             if (transfereeImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferorImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/TransferorImpl.java
@@ -46,32 +46,40 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class TransferorImpl extends HqdmObject implements Transferor {
     /**
+     * Constructs a new Transferor.
      *
-     * @param iri
+     * @param iri IRI of the Transferor.
      */
     public TransferorImpl(final IRI iri) {
         super(TransferorImpl.class, iri, TRANSFEROR);
     }
 
     /**
-     * Builder for TransferorImpl.
+     * Builder for constructing instances of Transferor.
      */
     public static class Builder {
-        /** */
+
         private final TransferorImpl transferorImpl;
 
         /**
+         * Constructs a Builder for a new Transferor.
          *
-         * @param iri
+         * @param iri IRI of the Transferor.
          */
         public Builder(final IRI iri) {
             transferorImpl = new TransferorImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may be aggregated into one or
+         * more others.
+         * <p>
+         * Note: This has the same meaning as, but different representation to, the
+         * {@link uk.gov.gchq.hqdm.model.Aggregation} entity type.
+         * </p>
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder aggregated_Into(final SpatioTemporalExtent spatioTemporalExtent) {
             transferorImpl.addValue(AGGREGATED_INTO, spatioTemporalExtent.getIri());
@@ -79,9 +87,11 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its beginning.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder beginning(final Event event) {
             transferorImpl.addValue(BEGINNING, event.getIri());
@@ -89,9 +99,15 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A relationship type where a {@link SpatioTemporalExtent} may consist of one or more
+         * others.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * <p>
+         * Note: This is the inverse of {@link uk.gov.gchq.hqdm.iri.HQDM#PART__OF}.
+         * </p>
+         *
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder consists__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferorImpl.addValue(CONSISTS__OF, spatioTemporalExtent.getIri());
@@ -99,9 +115,11 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} has exactly one {@link Event} that is its ending.
          *
-         * @param event
-         * @return
+         * @param event The Event.
+         * @return This builder.
          */
         public final Builder ending(final Event event) {
             transferorImpl.addValue(ENDING, event.getIri());
@@ -109,9 +127,11 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             transferorImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -119,9 +139,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a
+         * {@link uk.gov.gchq.hqdm.model.StateOfParty} may be a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link ClassOfStateOfParty}.
          *
-         * @param classOfStateOfParty
-         * @return
+         * @param classOfStateOfParty The ClassOfStateOfParty.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfStateOfParty classOfStateOfParty) {
             transferorImpl.addValue(MEMBER_OF, classOfStateOfParty.getIri());
@@ -129,9 +152,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF_KIND} relationship type where each
+         * {@link uk.gov.gchq.hqdm.model.Participant} is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} one or more {@link Role}.
          *
-         * @param role
-         * @return
+         * @param role The Role.
+         * @return This builder.
          */
         public final Builder member_Of_Kind_M(final Role role) {
             transferorImpl.addValue(MEMBER_OF_KIND, role.getIri());
@@ -139,9 +165,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * An {@link uk.gov.gchq.hqdm.iri.HQDM#AGGREGATED_INTO} relationship type where a
+         * {@link SpatioTemporalExtent} may be part of another and the whole has emergent properties
+         * and is more than just the sum of its parts.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder part__Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferorImpl.addValue(PART__OF, spatioTemporalExtent.getIri());
@@ -149,9 +178,17 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} one or more
+         * {@link PossibleWorld}.
          *
-         * @param possibleWorld
-         * @return
+         * <p>
+         * Note: The relationship is optional because a {@link PossibleWorld} is not
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} any other {@link SpatioTemporalExtent}.
+         * </p>
+         *
+         * @param possibleWorld The PossibleWorld.
+         * @return This builder.
          */
         public final Builder part_Of_Possible_World_M(final PossibleWorld possibleWorld) {
             transferorImpl.addValue(PART_OF_POSSIBLE_WORLD, possibleWorld.getIri());
@@ -159,11 +196,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
-         * A participant_in relationship type where a transferor is participant_in one or more
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} relationship type where a
+         * {@link Transferor} is {@link uk.gov.gchq.hqdm.iri.HQDM#PARTICIPANT_IN} one or more
          * {@link TransferOfOwnership}.
          *
-         * @param transferOfOwnership
-         * @return
+         * @param transferOfOwnership The TransferOfOwnership.
+         * @return This builder.
          */
         public final Builder participant_In_M(final TransferOfOwnership transferOfOwnership) {
             transferorImpl.addValue(PARTICIPANT_IN, transferOfOwnership.getIri());
@@ -171,9 +209,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#PART_OF} relationship type where a
+         * {@link SpatioTemporalExtent} may be a temporal part of one or more other
+         * {@link SpatioTemporalExtent}.
          *
-         * @param spatioTemporalExtent
-         * @return
+         * @param spatioTemporalExtent The SpatioTemporalExtent.
+         * @return This builder.
          */
         public final Builder temporal__Part_Of(final SpatioTemporalExtent spatioTemporalExtent) {
             transferorImpl.addValue(TEMPORAL__PART_OF, spatioTemporalExtent.getIri());
@@ -181,11 +222,12 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
-         * A temporal_part_of relationship type where a transferor is a temporal_part_of exactly one
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} relationship type where a
+         * {@link Transferor} is a {@link uk.gov.gchq.hqdm.iri.HQDM#TEMPORAL_PART_OF} exactly one
          * {@link Owner}.
          *
-         * @param owner
-         * @return
+         * @param owner The Owner.
+         * @return This builder.
          */
         public final Builder temporal_Part_Of(final Owner owner) {
             transferorImpl.addValue(TEMPORAL_PART_OF, owner.getIri());
@@ -193,9 +235,10 @@ public class TransferorImpl extends HqdmObject implements Transferor {
         }
 
         /**
+         * Returns an instance of Transferor created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built Transferor.
+         * @throws HqdmException If the Transferor is missing any mandatory properties.
          */
         public Transferor build() throws HqdmException {
             if (transferorImpl.hasValue(AGGREGATED_INTO)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/UnitOfMeasureImpl.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/UnitOfMeasureImpl.java
@@ -30,32 +30,36 @@ import uk.gov.gchq.hqdm.pojo.HqdmObject;
  */
 public class UnitOfMeasureImpl extends HqdmObject implements UnitOfMeasure {
     /**
+     * Constructs a new UnitOfMeasure.
      *
-     * @param iri
+     * @param iri IRI of the UnitOfMeasure.
      */
     public UnitOfMeasureImpl(final IRI iri) {
         super(UnitOfMeasureImpl.class, iri, UNIT_OF_MEASURE);
     }
 
     /**
-     * Builder for UnitOfMeasureImpl.
+     * Builder for constructing instances of UnitOfMeasure.
      */
     public static class Builder {
-        /** */
+
         private final UnitOfMeasureImpl unitOfMeasureImpl;
 
         /**
+         * Constructs a Builder for a new UnitOfMeasure.
          *
-         * @param iri
+         * @param iri IRI of the UnitOfMeasure.
          */
         public Builder(final IRI iri) {
             unitOfMeasureImpl = new UnitOfMeasureImpl(iri);
         }
 
         /**
+         * A relationship type where a {@link uk.gov.gchq.hqdm.model.Thing} may be a member of one
+         * or more {@link Class}.
          *
-         * @param clazz
-         * @return
+         * @param clazz The Class.
+         * @return This builder.
          */
         public final Builder member__Of(final Class clazz) {
             unitOfMeasureImpl.addValue(MEMBER__OF, clazz.getIri());
@@ -63,9 +67,11 @@ public class UnitOfMeasureImpl extends HqdmObject implements UnitOfMeasure {
         }
 
         /**
+         * A {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} relationship type where a relationship is a
+         * {@link uk.gov.gchq.hqdm.iri.HQDM#MEMBER_OF} a {@link ClassOfRelationship}.
          *
-         * @param classOfRelationship
-         * @return
+         * @param classOfRelationship The ClassOfRelationship.
+         * @return This builder.
          */
         public final Builder member_Of(final ClassOfRelationship classOfRelationship) {
             unitOfMeasureImpl.addValue(MEMBER_OF, classOfRelationship.getIri());
@@ -73,9 +79,10 @@ public class UnitOfMeasureImpl extends HqdmObject implements UnitOfMeasure {
         }
 
         /**
+         * Returns an instance of UnitOfMeasure created from the properties set on this builder.
          *
-         * @return
-         * @throws HqdmException
+         * @return The built UnitOfMeasure.
+         * @throws HqdmException If the UnitOfMeasure is missing any mandatory properties.
          */
         public UnitOfMeasure build() throws HqdmException {
             if (unitOfMeasureImpl.hasValue(MEMBER__OF)

--- a/src/main/java/uk/gov/gchq/hqdm/model/impl/package-info.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/impl/package-info.java
@@ -1,4 +1,18 @@
-/**
+/*
+ * Copyright 2021 Crown Copyright
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Basic implementations for HQDM Java objects defined in {@code uk.gov.gchq.hqdm.model}.
  */
 package uk.gov.gchq.hqdm.model.impl;

--- a/src/main/java/uk/gov/gchq/hqdm/model/package-info.java
+++ b/src/main/java/uk/gov/gchq/hqdm/model/package-info.java
@@ -1,4 +1,18 @@
-/**
+/*
+ * Copyright 2021 Crown Copyright
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * HQDM object interfaces defining HQDM class inheritance.
  */
 package uk.gov.gchq.hqdm.model;

--- a/src/main/java/uk/gov/gchq/hqdm/pojo/HqdmObject.java
+++ b/src/main/java/uk/gov/gchq/hqdm/pojo/HqdmObject.java
@@ -31,27 +31,29 @@ import uk.gov.gchq.hqdm.iri.IRI;
 import uk.gov.gchq.hqdm.model.Thing;
 
 /**
- *
+ * Basic implementation of a HQDM object.
  */
 public abstract class HqdmObject implements Thing {
 
     private static final Pattern DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
     private static final Pattern DATE_TIME_PATTERN = Pattern
             .compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*");
+
     private IRI iri;
 
     private final Map<IRI, Set<Object>> predicates = new HashMap<>();
 
     /**
-     *
+     * Constructs a new instance of a {@code HqdmObject}.
      */
     public HqdmObject() {}
 
     /**
+     * Constructs a new {@code HqdmObject}.
      *
-     * @param clazz
-     * @param iri
-     * @param rdfType
+     * @param clazz Class of HQDM object.
+     * @param iri IRI of the HQDM object.
+     * @param rdfType IRI definition of HQDM object type.
      */
     public HqdmObject(final Class clazz, final IRI iri, final IRI rdfType) {
         addStringValue(ENTITY_CLASS_NAME, clazz.getName());
@@ -71,6 +73,19 @@ public abstract class HqdmObject implements Thing {
      */
     public void setIri(final IRI iri) {
         this.iri = iri;
+    }
+
+    /**
+     * Return the {@link uk.gov.gchq.hqdm.iri.HQDM#ENTITY_NAME} value of the entity.
+     *
+     * @return Name of the entity.
+     */
+    public String getName() {
+        final Set<Object> names = value(ENTITY_NAME);
+        if (names != null && !names.isEmpty()) {
+            return (String) names.iterator().next();
+        }
+        return null;
     }
 
     /**
@@ -103,18 +118,6 @@ public abstract class HqdmObject implements Thing {
     }
 
     /**
-     *
-     * @return
-     */
-    public String getName() {
-        final Set<Object> names = value(ENTITY_NAME);
-        if (names != null && !names.isEmpty()) {
-            return (String) names.iterator().next();
-        }
-        return null;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public void addValue(final IRI predicateIri, final IRI value) {
@@ -141,15 +144,15 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public boolean hasValue(final IRI value) {
-        return predicates.containsKey(value);
+    public Set<Object> value(final IRI iri) {
+        return predicates.get(iri);
     }
 
     /**
      * {@inheritDoc}
      */
-    public Set<Object> value(final IRI iri) {
-        return predicates.get(iri);
+    public boolean hasValue(final IRI value) {
+        return predicates.containsKey(value);
     }
 
     /**
@@ -239,8 +242,9 @@ public abstract class HqdmObject implements Thing {
     }
 
     /**
+     * Output HQDM object and predicate values as collection of string values including predicates.
      *
-     * @return
+     * @return Formatted string output of HQDM object.
      */
     @Override
     public String toString() {
@@ -259,9 +263,10 @@ public abstract class HqdmObject implements Thing {
     }
 
     /**
+     * Indicates whether some other object is "equal to" this one.
      *
-     * @param object
-     * @return
+     * @param object The reference object with which to compare.
+     * @return {@code true} if this object is the same as the obj argument; false otherwise.
      */
     @Override
     public boolean equals(final Object object) {
@@ -279,8 +284,9 @@ public abstract class HqdmObject implements Thing {
     }
 
     /**
+     * Returns a hash code value for the object.
      *
-     * @return
+     * @return A hash code value for this object.
      */
     @Override
     public int hashCode() {

--- a/src/main/java/uk/gov/gchq/hqdm/pojo/Top.java
+++ b/src/main/java/uk/gov/gchq/hqdm/pojo/Top.java
@@ -21,104 +21,119 @@ import uk.gov.gchq.hqdm.exception.HqdmException;
 import uk.gov.gchq.hqdm.iri.IRI;
 
 /**
- *
+ * Top-level interface for HQDM objects.
  */
 public interface Top {
+
     /**
+     * Get the IRI of the HQDM object.
      *
-     * @return class IRI
+     * @return IRI of the HQDM object.
      */
     IRI getIri();
 
     /**
+     * Set the IRI of the HQDM object.
      *
-     * @param iri
+     * @param iri IRI of the HQDM object.
      */
     void setIri(IRI iri);
 
     /**
+     * Get the predications of the HQDM object.
      *
-     * @return
+     * @return Map of HQDM objects and IRI predicates of the entity.
      */
     Map<IRI, Set<Object>> getPredicates();
 
     /**
+     * Set the predications of the HQDM object.
      *
-     * @param predicates
-     * @throws HqdmException
+     * @param predicates Predicates of the HQDM object.
+     * @throws HqdmException If predicates could not be parsed.
      */
     void setPredicates(Map<IRI, Set<Object>> predicates) throws HqdmException;
 
     /**
+     * Add predicate and object IRI reference to entity.
      *
-     * @param predicateIri
-     * @param value
+     * @param predicateIri Predicate IRI.
+     * @param objectIri IRI of the object.
      */
-    void addValue(IRI predicateIri, IRI value);
+    void addValue(IRI predicateIri, IRI objectIri);
 
     /**
+     * Add predicate IRI and string value to object.
      *
-     * @param predicateIri
-     * @param value
+     * @param predicateIri Predicate IRI.
+     * @param value String value.
      */
     void addStringValue(IRI predicateIri, String value);
 
     /**
+     * Add predicate IRI and real number value to object.
      *
-     * @param predicateIri
-     * @param value
+     * @param predicateIri Predicate IRI.
+     * @param value Real number value.
      */
     void addRealValue(IRI predicateIri, double value);
 
     /**
+     * Get predicate value(s) by predicate IRI.
      *
-     * @param value
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @return Set of predicate values (IRIs or string-literals).
      */
-    boolean hasValue(IRI value);
+    Set<Object> value(IRI predicateIri);
 
     /**
+     * Does the entity have a given predicate.
      *
-     * @param iri
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @return True if has predicate value.
      */
-    Set<Object> value(IRI iri);
+    boolean hasValue(IRI predicateIri);
 
     /**
+     * Does the entity have a given predicate and IRI value.
      *
-     * @param predicateIri
-     * @param value
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @param value Object IRI.
+     * @return True if has this IRI value.
      */
     boolean hasThisValue(IRI predicateIri, IRI value);
 
     /**
+     * Does the entity have a given predicate and string value.
      *
-     * @param predicateIri
-     * @param value
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @param value String value.
+     * @return True if has this string value.
      */
     boolean hasThisStringValue(IRI predicateIri, String value);
 
     /**
+     * Does the entity have a given predicate and string value (case-insensitive).
      *
-     * @param predicateIri
-     * @param value
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @param value Case-insensitive string value.
+     * @return True if has this string value.
      */
     boolean hasThisStringValueIgnoreCase(IRI predicateIri, String value);
 
     /**
+     * Does the entity have a given predicate and string value.
      *
-     * @param predicateIri
-     * @param value
-     * @return
+     * @param predicateIri Predicate IRI.
+     * @param value String value.
+     * @return True if has fuzzy string value.
      */
     boolean hasThisStringValueFuzzy(IRI predicateIri, String value);
 
     /**
+     * Convert the object to string of RDF triples.
      *
-     * @return
+     * @return The object as RDF triples.
      */
     String toTriples();
 }

--- a/src/main/java/uk/gov/gchq/hqdm/pojo/package-info.java
+++ b/src/main/java/uk/gov/gchq/hqdm/pojo/package-info.java
@@ -1,4 +1,18 @@
-/**
+/*
+ * Copyright 2021 Crown Copyright
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Classes for constructing HQDM entities as Java objects.
  */
 package uk.gov.gchq.hqdm.pojo;


### PR DESCRIPTION
Added Javadoc comments documenting HQDM code where appropriate.

I recommend reviewing these changes as the rendered Javadocs. These can be built with `mvn javadoc:javadoc`. Then navigate to and open `target/site/apidocs/index.html`.

## Conflicting Relationship Type Definitions

Some of the relationship types defined in `HQDM.java` do not have standard descriptions in the documentation, or are defined differently by different entities. These entity descriptions still need resolving before this PR is merged, either by redefining/merging the descriptions, or selecting one of the given descriptions as the *primary* definition.

Conflicts: 
- `CONSISTS_OF_` - AgreeContract, AgreementProcess, ExchangeOfGoodsAndMoney, RepresentationBySign
- `CONSISTS_OF_BY_CLASS` - KindOfActivity, KindOfAssociation, RepresentationBySign
- `CONSISTS_OF_PARTICIPANT` - Activity, Association
- `CONSISTS_OF_PARTICIPANT_` - Employment, Ownership, TransferOfOwnership, 
- `MEMBER_OF_` - ClassOfSpatioTemporalExtent, Sign, RepresentationBySign
- `MEMBER_OF_KIND` - Participant, Individual, DefinedRelationship
- `PART_OF_BY_CLASS` - Role, ClassOfSociallyConstructedActivity
- `PART_OF_BY_CLASS_` - Role, ClassOfSociallyConstructedActivity